### PR TITLE
Add pagination support for list endpoints

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "perl": "6.d",
     "auth": "github:wkusnierczyk",
     "license": "MIT",

--- a/META6.json
+++ b/META6.json
@@ -23,7 +23,8 @@
     },
     "depends": [
         "JSON::Fast",
-        "Cro::HTTP"
+        "Cro::HTTP",
+        "MIME::Base64"
     ],
     "test-depends": [
         "Test",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.2.0
+VERSION         := 0.3.0
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk
@@ -658,7 +658,7 @@ ifneq ($(VERSION_NEW),)
 		exit 1; \
 	fi
 	$(call log-info,Updating project version to $(VERSION_NEW)...)
-	$(Q)perl -0pi -e 's/^VERSION\\s*:=\\s*.*/VERSION         := $(VERSION_NEW)/m' Makefile
+	$(Q)perl -0pi -e 's/^VERSION\\s*:=\\s*.*/VERSION := $(VERSION_NEW)/m' Makefile
 	$(Q)perl -0pi -e 's/"version"\\s*:\\s*"[^"]*"/"version": "$(VERSION_NEW)"/' $(META_FILE)
 	$(call log-success,Version updated in Makefile and $(META_FILE))
 	$(call log-info,Creating git tag v$(VERSION_NEW)...)

--- a/lib/MCP/Client.rakumod
+++ b/lib/MCP/Client.rakumod
@@ -169,9 +169,13 @@ class Client is export {
     }
 
     #| List available tools
-    method list-tools(--> Promise) {
-        self.request('tools/list').then(-> $p {
-            $p.result<tools>.map({ MCP::Types::Tool.from-hash($_) }).Array
+    method list-tools(Str :$cursor --> Promise) {
+        my %params = $cursor ?? (cursor => $cursor) !! ();
+        self.request('tools/list', %params || Nil).then(-> $p {
+            {
+                tools => $p.result<tools>.map({ MCP::Types::Tool.from-hash($_) }).Array,
+                ($p.result<nextCursor> ?? (nextCursor => $p.result<nextCursor>) !! Empty),
+            }
         })
     }
 
@@ -191,9 +195,13 @@ class Client is export {
     }
 
     #| List available resources
-    method list-resources(--> Promise) {
-        self.request('resources/list').then(-> $p {
-            $p.result<resources>.map({ MCP::Types::Resource.from-hash($_) }).Array
+    method list-resources(Str :$cursor --> Promise) {
+        my %params = $cursor ?? (cursor => $cursor) !! ();
+        self.request('resources/list', %params || Nil).then(-> $p {
+            {
+                resources => $p.result<resources>.map({ MCP::Types::Resource.from-hash($_) }).Array,
+                ($p.result<nextCursor> ?? (nextCursor => $p.result<nextCursor>) !! Empty),
+            }
         })
     }
 
@@ -221,9 +229,13 @@ class Client is export {
     }
 
     #| List available prompts
-    method list-prompts(--> Promise) {
-        self.request('prompts/list').then(-> $p {
-            $p.result<prompts>.map({ MCP::Types::Prompt.from-hash($_) }).Array
+    method list-prompts(Str :$cursor --> Promise) {
+        my %params = $cursor ?? (cursor => $cursor) !! ();
+        self.request('prompts/list', %params || Nil).then(-> $p {
+            {
+                prompts => $p.result<prompts>.map({ MCP::Types::Prompt.from-hash($_) }).Array,
+                ($p.result<nextCursor> ?? (nextCursor => $p.result<nextCursor>) !! Empty),
+            }
         })
     }
 

--- a/t/05-server.rakutest
+++ b/t/05-server.rakutest
@@ -10,6 +10,8 @@ use MCP::Server::Tool;
 use MCP::Server::Resource;
 use MCP::Server::Prompt;
 need TestTransport;
+use JSON::Fast;
+use MIME::Base64;
 
 =begin pod
 =head1 NAME
@@ -153,6 +155,116 @@ subtest 'Server dispatch and handlers', {
 
     $server.handle-message-public(MCP::JSONRPC::Notification.new(method => 'initialized'));
     $server.handle-message-public(MCP::JSONRPC::Notification.new(method => 'cancelled', params => { requestId => 1 }));
+};
+
+subtest 'Pagination support', {
+    my $transport = TestTransport::TestTransport.new;
+    my $server = Server.new(
+        info => MCP::Types::Implementation.new(name => 'srv', version => '0.1'),
+        transport => $transport,
+        page-size => 2  # Small page size for testing
+    );
+
+    # Add 5 tools to test pagination
+    for 1..5 -> $i {
+        $server.add-tool(
+            name => "tool$i",
+            description => "Tool $i",
+            handler => -> { "result$i" }
+        );
+    }
+
+    # Test first page - should have 2 items and nextCursor
+    my $page1 = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 1,
+        method => 'tools/list'
+    ));
+    is $page1<tools>.elems, 2, 'first page has 2 items';
+    ok $page1<nextCursor>.defined, 'first page has nextCursor';
+
+    # Test using cursor returns next page
+    my $page2 = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 2,
+        method => 'tools/list',
+        params => { cursor => $page1<nextCursor> }
+    ));
+    is $page2<tools>.elems, 2, 'second page has 2 items';
+    ok $page2<nextCursor>.defined, 'second page has nextCursor';
+
+    # Ensure pages have different items
+    my @page1-names = $page1<tools>.map(*<name>);
+    my @page2-names = $page2<tools>.map(*<name>);
+    ok @page1-names ne @page2-names, 'pages have different items';
+
+    # Test last page has no nextCursor
+    my $page3 = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 3,
+        method => 'tools/list',
+        params => { cursor => $page2<nextCursor> }
+    ));
+    is $page3<tools>.elems, 1, 'last page has 1 item';
+    nok $page3<nextCursor>.defined, 'last page has no nextCursor';
+
+    # Test invalid cursor returns InvalidParams error
+    dies-ok {
+        $server.dispatch-request(MCP::JSONRPC::Request.new(
+            id => 4,
+            method => 'tools/list',
+            params => { cursor => 'invalid-cursor' }
+        ));
+    }, 'invalid cursor raises error';
+
+    # Test malformed base64 cursor
+    dies-ok {
+        $server.dispatch-request(MCP::JSONRPC::Request.new(
+            id => 5,
+            method => 'tools/list',
+            params => { cursor => '!!!' }
+        ));
+    }, 'malformed cursor raises error';
+
+    # Test empty list returns no nextCursor
+    my $empty-server = Server.new(
+        info => MCP::Types::Implementation.new(name => 'srv', version => '0.1'),
+        transport => $transport,
+        page-size => 2
+    );
+    my $empty-result = $empty-server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 6,
+        method => 'tools/list'
+    ));
+    is $empty-result<tools>.elems, 0, 'empty list has 0 items';
+    nok $empty-result<nextCursor>.defined, 'empty list has no nextCursor';
+
+    # Test pagination for resources
+    for 1..3 -> $i {
+        $server.add-resource(
+            uri => "info://res$i",
+            name => "Resource $i",
+            reader => { "content$i" }
+        );
+    }
+    my $res-page1 = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 7,
+        method => 'resources/list'
+    ));
+    is $res-page1<resources>.elems, 2, 'resources first page has 2 items';
+    ok $res-page1<nextCursor>.defined, 'resources first page has nextCursor';
+
+    # Test pagination for prompts
+    for 1..3 -> $i {
+        $server.add-prompt(
+            name => "prompt$i",
+            description => "Prompt $i",
+            generator => { "message$i" }
+        );
+    }
+    my $prompt-page1 = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 8,
+        method => 'prompts/list'
+    ));
+    is $prompt-page1<prompts>.elems, 2, 'prompts first page has 2 items';
+    ok $prompt-page1<nextCursor>.defined, 'prompts first page has nextCursor';
 };
 
 done-testing;

--- a/t/06-client.rakutest
+++ b/t/06-client.rakutest
@@ -63,8 +63,9 @@ subtest 'Client connect and requests', {
     respond-to-last($transport, {
         tools => [ %tool.item ]
     });
-    my @tools = await $tools-p;
-    is @tools[0].name, 't', 'list-tools returns Tool';
+    my $tools-result = await $tools-p;
+    is $tools-result<tools>[0].name, 't', 'list-tools returns Tool';
+    nok $tools-result<nextCursor>.defined, 'list-tools has no nextCursor when not paginated';
 
     my $call-p = $client.call-tool('add', arguments => { a => 1, b => 2 });
     my %content = type => 'text', text => 'ok';
@@ -80,8 +81,9 @@ subtest 'Client connect and requests', {
     respond-to-last($transport, {
         resources => [ %resource.item ]
     });
-    my @resources = await $res-p;
-    is @resources[0].uri, 'info://x', 'list-resources returns Resource';
+    my $res-result = await $res-p;
+    is $res-result<resources>[0].uri, 'info://x', 'list-resources returns Resource';
+    nok $res-result<nextCursor>.defined, 'list-resources has no nextCursor when not paginated';
 
     my $read-p = $client.read-resource('info://x');
     my %contents = uri => 'info://x', mimeType => 'text/plain', text => 'hello';
@@ -96,8 +98,9 @@ subtest 'Client connect and requests', {
     respond-to-last($transport, {
         prompts => [ %prompt.item ]
     });
-    my @prompts = await $prompts-p;
-    is @prompts[0].name, 'p', 'list-prompts returns Prompt';
+    my $prompts-result = await $prompts-p;
+    is $prompts-result<prompts>[0].name, 'p', 'list-prompts returns Prompt';
+    nok $prompts-result<nextCursor>.defined, 'list-prompts has no nextCursor when not paginated';
 
     my $prompt-p = $client.get-prompt('p', arguments => { });
     my %msg = role => 'user', content => { type => 'text', text => 'hi' };
@@ -128,6 +131,74 @@ subtest 'Client connect and requests', {
     $transport.clear-sent;
     $transport.emit(MCP::JSONRPC::Request.new(id => 99, method => 'server/request'));
     ok $transport.sent.grep(MCP::JSONRPC::Response).elems == 1, 'client responds to server request';
+};
+
+subtest 'Client pagination support', {
+    my $transport = TestTransport::TestTransport.new;
+    my $client = Client.new(
+        info => MCP::Types::Implementation.new(name => 'cli', version => '0.1'),
+        transport => $transport
+    );
+
+    my $connect = $client.connect;
+    for ^10 {
+        last if $transport.sent.elems > 0;
+        sleep 0.1;
+    }
+    my $init-req = $transport.sent[0];
+    $transport.emit(MCP::JSONRPC::Response.success($init-req.id, {
+        protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
+        capabilities => {},
+        instructions => 'test'
+    }));
+    await $connect;
+
+    # Test list-tools with nextCursor
+    my $tools-p = $client.list-tools;
+    my %tool = name => 't1', description => 'd', inputSchema => { type => 'object' };
+    respond-to-last($transport, {
+        tools => [ %tool.item ],
+        nextCursor => 'cursor123'
+    });
+    my $tools-result = await $tools-p;
+    is $tools-result<tools>[0].name, 't1', 'list-tools returns Tool';
+    is $tools-result<nextCursor>, 'cursor123', 'list-tools includes nextCursor';
+
+    # Test list-tools with cursor parameter
+    my $tools-p2 = $client.list-tools(cursor => 'cursor123');
+    my $req = $transport.sent[*-1];
+    is $req.params<cursor>, 'cursor123', 'list-tools sends cursor parameter';
+    my %tool2 = name => 't2', description => 'd2', inputSchema => { type => 'object' };
+    respond-to-last($transport, {
+        tools => [ %tool2.item ]
+    });
+    my $tools-result2 = await $tools-p2;
+    is $tools-result2<tools>[0].name, 't2', 'list-tools with cursor returns next page';
+    nok $tools-result2<nextCursor>.defined, 'last page has no nextCursor';
+
+    # Test list-resources with cursor
+    my $res-p = $client.list-resources(cursor => 'rescursor');
+    my $res-req = $transport.sent[*-1];
+    is $res-req.params<cursor>, 'rescursor', 'list-resources sends cursor parameter';
+    my %res = uri => 'info://x', name => 'X', mimeType => 'text/plain';
+    respond-to-last($transport, {
+        resources => [ %res.item ],
+        nextCursor => 'rescursor2'
+    });
+    my $res-result = await $res-p;
+    is $res-result<nextCursor>, 'rescursor2', 'list-resources includes nextCursor';
+
+    # Test list-prompts with cursor
+    my $prompts-p = $client.list-prompts(cursor => 'promptcursor');
+    my $prompts-req = $transport.sent[*-1];
+    is $prompts-req.params<cursor>, 'promptcursor', 'list-prompts sends cursor parameter';
+    my %pmt = name => 'p', description => 'desc', arguments => [];
+    respond-to-last($transport, {
+        prompts => [ %pmt.item ],
+        nextCursor => 'promptcursor2'
+    });
+    my $prompts-result = await $prompts-p;
+    is $prompts-result<nextCursor>, 'promptcursor2', 'list-prompts includes nextCursor';
 };
 
 done-testing;


### PR DESCRIPTION
Implement cursor-based pagination for tools/list, resources/list, and prompts/list endpoints per MCP specification 2025-11-25.

Server changes:
- Add page-size attribute (default: 50) to Server class
- Add cursor encoding/decoding using base64 JSON
- Add paginate helper that slices items and generates nextCursor
- Return InvalidParams error (-32602) for invalid cursors

Client changes:
- Update list-tools, list-resources, list-prompts to accept :$cursor
- Return Hash with items array and optional nextCursor (breaking change)