### PR TITLE
Implement proper request cancellation

### DIFF
--- a/GAP_ANALYSIS.md
+++ b/GAP_ANALYSIS.md
@@ -14,7 +14,7 @@ This document compares the current implementation of the Raku MCP SDK against th
 | **Transports** | ⚠️ Partial | Stdio complete, Streamable HTTP started |
 | **Server Features** | ⚠️ Partial | Tools/Resources/Prompts basic support |
 | **Client Features** | ⚠️ Partial | Sampling basic support |
-| **Utilities** | ⚠️ Partial | Logging, progress basic; missing cancellation |
+| **Utilities** | ⚠️ Partial | Logging, progress, cancellation implemented |
 | **Authorization** | ❌ Missing | OAuth 2.1 not implemented |
 | **New 2025-11-25 Features** | ❌ Missing | Tasks, Extensions, URL Elicitation |
 
@@ -140,12 +140,11 @@ This document compares the current implementation of the Raku MCP SDK against th
 - ❌ `logging/setLevel` request
 - ❌ Client-side log level configuration
 
-#### ❌ Cancellation
-- `cancelled` notification is received but not acted upon
-- Missing:
-  - Proper request cancellation mechanism
-  - `notifications/cancelled` sending from client
-  - Timeout-based auto-cancellation
+#### ✅ Cancellation - **Implemented**
+- Server tracks in-flight requests and handles `notifications/cancelled`
+- Client sends cancellation notification on timeout
+- Both sides have `cancel-request` method for explicit cancellation
+- `is-cancelled` method for handlers to check cancellation status
 
 #### ❌ Ping
 - Server responds to `ping` requests
@@ -233,7 +232,7 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 2. **Add resource subscriptions** - Common use case for file watching
 3. ~~**Add pagination**~~ ✅ **Done** - Cursor-based pagination for all list endpoints
 4. **Implement roots** - Required for filesystem-based servers
-5. **Implement proper cancellation** - Important for long-running operations
+5. ~~**Implement proper cancellation**~~ ✅ **Done** - Request cancellation with notifications
 
 ### Medium Priority (Enhanced Functionality)
 6. **Add tool output schemas** - Better structured responses
@@ -289,7 +288,7 @@ Current tests cover:
 Missing tests for:
 - ❌ Resource subscriptions
 - ✅ Pagination - **Implemented**
-- ❌ Cancellation
+- ✅ Cancellation - **Implemented**
 - ❌ Progress tracking
 - ❌ HTTP transport (partial)
 - ❌ Error edge cases

--- a/GAP_ANALYSIS.md
+++ b/GAP_ANALYSIS.md
@@ -71,7 +71,7 @@ This document compares the current implementation of the Raku MCP SDK against th
 - ❌ Tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) - types exist but not used in registration
 - ❌ `outputSchema` for structured tool outputs (2025-06-18 feature)
 - ❌ Tool name validation (SEP-986: must match `^[a-zA-Z0-9_-]{1,64}$`)
-- ❌ `tools/list` pagination support
+- ✅ `tools/list` pagination support - **Implemented**
 
 #### ✅ Resources (`MCP::Server::Resource`)
 - Resource registration with URI, name, description, mimeType
@@ -82,7 +82,7 @@ This document compares the current implementation of the Raku MCP SDK against th
 - ❌ Resource subscriptions (`resources/subscribe`, `resources/unsubscribe`)
 - ❌ `notifications/resources/list_changed`
 - ❌ `notifications/resources/updated` for subscribed resources
-- ❌ `resources/list` pagination support
+- ✅ `resources/list` pagination support - **Implemented**
 - ❌ Resource annotations
 
 #### ✅ Prompts (`MCP::Server::Prompt`)
@@ -90,7 +90,7 @@ This document compares the current implementation of the Raku MCP SDK against th
 - Prompt retrieval with argument substitution
 
 **Missing**:
-- ❌ `prompts/list` pagination support
+- ✅ `prompts/list` pagination support - **Implemented**
 - ❌ `notifications/prompts/list_changed`
 
 ---
@@ -222,7 +222,7 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 | SSE Transport | ✅ Full | ❌ No |
 | Tasks | ✅ Experimental | ❌ No |
 | Completion | ✅ Full | ❌ No |
-| Pagination | ✅ Full | ❌ No |
+| Pagination | ✅ Full | ✅ Full |
 
 ---
 
@@ -231,7 +231,7 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 ### High Priority (Core Functionality)
 1. **Complete Streamable HTTP transport** - Required for remote deployments
 2. **Add resource subscriptions** - Common use case for file watching
-3. **Add pagination** - Required for large tool/resource/prompt lists
+3. ~~**Add pagination**~~ ✅ **Done** - Cursor-based pagination for all list endpoints
 4. **Implement roots** - Required for filesystem-based servers
 5. **Implement proper cancellation** - Important for long-running operations
 
@@ -288,7 +288,7 @@ Current tests cover:
 
 Missing tests for:
 - ❌ Resource subscriptions
-- ❌ Pagination
+- ✅ Pagination - **Implemented**
 - ❌ Cancellation
 - ❌ Progress tracking
 - ❌ HTTP transport (partial)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See [Gap Analysis](GAP_ANALYSIS.md) for details on implemented and missing featu
 | Progress | ✅ Done | Server-side notifications |
 | Sampling | ⚠️ Partial | Basic support, missing tools in sampling |
 | HTTP Transport | ⚠️ Partial | Server started, client missing |
-| Cancellation | ❌ Planned | Issue #13 |
+| Cancellation | ✅ Done | Request cancellation support |
 | Resource subscriptions | ❌ Planned | |
 | Roots | ❌ Planned | |
 | OAuth 2.1 | ❌ Planned | |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,26 @@
 
 **Work in progress**
 
-See [Gap Analysis](GAP_ANALYSIS.md) for details in implemented and missing features, in the context of the most recent [MCP specification](https://modelcontextprotocol.io/specification/2025-11-25).
+See [Gap Analysis](GAP_ANALYSIS.md) for details on implemented and missing features, in the context of the most recent [MCP specification](https://modelcontextprotocol.io/specification/2025-11-25).
+
+### Implementation Progress
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| JSON-RPC 2.0 | ✅ Done | Full message handling |
+| Stdio Transport | ✅ Done | Production ready |
+| Tools | ✅ Done | List, call, builder API |
+| Resources | ✅ Done | List, read, builder API |
+| Prompts | ✅ Done | List, get, builder API |
+| Pagination | ✅ Done | Cursor-based for all list endpoints |
+| Logging | ✅ Done | Server-side notifications |
+| Progress | ✅ Done | Server-side notifications |
+| Sampling | ⚠️ Partial | Basic support, missing tools in sampling |
+| HTTP Transport | ⚠️ Partial | Server started, client missing |
+| Cancellation | ❌ Planned | Issue #13 |
+| Resource subscriptions | ❌ Planned | |
+| Roots | ❌ Planned | |
+| OAuth 2.1 | ❌ Planned | |
 
 ## Table of contents
 
@@ -221,14 +240,15 @@ my $client = MCP::Client::Client.new(
 
 await $client.connect;
 
-# List and call tools
-my @tools = await $client.list-tools;
-for @tools -> $tool {
+# List and call tools (with pagination support)
+my $tools-result = await $client.list-tools;
+for $tools-result<tools> -> $tool {
     say "Tool: $tool.name() - $tool.description()";
 }
+# Use $tools-result<nextCursor> for pagination if present
 
-my $result = await $client.call-tool('greet', arguments => { name => 'World' });
-say $result.content[0].text;  # "Hello, World!"
+my $call-result = await $client.call-tool('greet', arguments => { name => 'World' });
+say $call-result.content[0].text;  # "Hello, World!"
 
 # Read resources
 my @contents = await $client.read-resource('info://about');

--- a/t/05-server.rakutest
+++ b/t/05-server.rakutest
@@ -267,4 +267,43 @@ subtest 'Pagination support', {
     ok $prompt-page1<nextCursor>.defined, 'prompts first page has nextCursor';
 };
 
+subtest 'Cancellation support', {
+    my $transport = TestTransport::TestTransport.new;
+    my $server = Server.new(
+        info => MCP::Types::Implementation.new(name => 'srv', version => '0.1'),
+        transport => $transport
+    );
+
+    # Test is-cancelled returns False for unknown request
+    nok $server.is-cancelled('unknown-id'), 'is-cancelled returns False for unknown request';
+
+    # Test cancellation notification is handled
+    # We need to simulate an in-flight request being cancelled
+    # Since dispatch-request is synchronous for simple handlers, we test the notification handling
+
+    # Test that notifications/cancelled is accepted (doesn't throw)
+    lives-ok {
+        $server.handle-message-public(MCP::JSONRPC::Notification.new(
+            method => 'notifications/cancelled',
+            params => { requestId => 'some-id', reason => 'test' }
+        ));
+    }, 'notifications/cancelled is handled without error';
+
+    # Test cancel-request sends notification
+    $transport.clear-sent;
+    $server.cancel-request('req-123', reason => 'User cancelled');
+    my @notifications = $transport.sent.grep(MCP::JSONRPC::Notification);
+    is @notifications.elems, 1, 'cancel-request sends notification';
+    is @notifications[0].method, 'notifications/cancelled', 'notification method is correct';
+    is @notifications[0].params<requestId>, 'req-123', 'notification has correct requestId';
+    is @notifications[0].params<reason>, 'User cancelled', 'notification has correct reason';
+
+    # Test cancel-request without reason
+    $transport.clear-sent;
+    $server.cancel-request('req-456');
+    @notifications = $transport.sent.grep(MCP::JSONRPC::Notification);
+    is @notifications.elems, 1, 'cancel-request without reason sends notification';
+    nok @notifications[0].params<reason>:exists, 'notification has no reason when not provided';
+};
+
 done-testing;

--- a/t/06-client.rakutest
+++ b/t/06-client.rakutest
@@ -201,4 +201,49 @@ subtest 'Client pagination support', {
     is $prompts-result<nextCursor>, 'promptcursor2', 'list-prompts includes nextCursor';
 };
 
+subtest 'Client cancellation support', {
+    my $transport = TestTransport::TestTransport.new;
+    my $client = Client.new(
+        info => MCP::Types::Implementation.new(name => 'cli', version => '0.1'),
+        transport => $transport
+    );
+
+    my $connect = $client.connect;
+    for ^10 {
+        last if $transport.sent.elems > 0;
+        sleep 0.1;
+    }
+    my $init-req = $transport.sent[0];
+    $transport.emit(MCP::JSONRPC::Response.success($init-req.id, {
+        protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
+        capabilities => {},
+        instructions => 'test'
+    }));
+    await $connect;
+
+    # Test cancel-request sends notification
+    $transport.clear-sent;
+    $client.cancel-request('req-789', reason => 'User cancelled');
+    my @notifications = $transport.sent.grep(MCP::JSONRPC::Notification);
+    is @notifications.elems, 1, 'cancel-request sends notification';
+    is @notifications[0].method, 'notifications/cancelled', 'notification method is correct';
+    is @notifications[0].params<requestId>, 'req-789', 'notification has correct requestId';
+    is @notifications[0].params<reason>, 'User cancelled', 'notification has correct reason';
+
+    # Test cancel-request for pending request breaks the promise
+    $transport.clear-sent;
+    my $pending = $client.request('some/method');
+    my $req = $transport.sent.grep(MCP::JSONRPC::Request)[*-1];
+    $client.cancel-request($req.id, reason => 'Cancelled by test');
+
+    # The promise should be broken
+    dies-ok { await $pending }, 'cancelled request breaks promise';
+
+    # And a notification should have been sent
+    @notifications = $transport.sent.grep(MCP::JSONRPC::Notification);
+    ok @notifications.elems >= 1, 'cancellation notification was sent';
+    my $cancel-notif = @notifications.first({ $_.method eq 'notifications/cancelled' });
+    ok $cancel-notif.defined, 'notifications/cancelled was sent';
+};
+
 done-testing;


### PR DESCRIPTION
## Summary
Implement full cancellation support for in-flight requests.

## Current State
- `cancelled` notification is received but not acted upon
- No mechanism to cancel long-running operations

## Requirements
- Track in-flight requests that can be cancelled
- Handle `notifications/cancelled` and abort corresponding operations
- Client should send cancellation when timing out
- Add `_meta.progressToken` support for cancellable requests

## References
- [MCP Specification - Cancellation](https://modelcontextprotocol.io/specification/2025-11-25)