### PR TITLE
Wire up tool and resource annotations in builders

### DIFF
--- a/GAP_ANALYSIS.md
+++ b/GAP_ANALYSIS.md
@@ -68,7 +68,7 @@ This document compares the current implementation of the Raku MCP SDK against th
 - Builder pattern API
 
 **Missing**:
-- ❌ Tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) - types exist but not used in registration
+- ✅ Tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) - **Implemented** via builder API
 - ❌ `outputSchema` for structured tool outputs (2025-06-18 feature)
 - ❌ Tool name validation (SEP-986: must match `^[a-zA-Z0-9_-]{1,64}$`)
 - ✅ `tools/list` pagination support - **Implemented**
@@ -83,7 +83,7 @@ This document compares the current implementation of the Raku MCP SDK against th
 - ❌ `notifications/resources/list_changed`
 - ❌ `notifications/resources/updated` for subscribed resources
 - ✅ `resources/list` pagination support - **Implemented**
-- ❌ Resource annotations
+- ✅ Resource annotations (`audience`, `priority`) - **Implemented** via builder API
 
 #### ✅ Prompts (`MCP::Server::Prompt`)
 - Prompt registration with arguments

--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ $ make about
 Raku MCP SDK: Raku Implementation of the Model Context Protocol
 ├─ version:    x.y.z
 ├─ developer:  mailto:waclaw.kusnierczyk@gmail.com
+├─ support:    Claude Opus 4.5 <noreply@anthropic.com>
 ├─ source:     https://github.com/wkusnierczyk/raku-mcp-sdk
 └─ licence:    MIT https://opensource.org/licenses/MIT
 ```

--- a/lib/MCP/Server/Tool.rakumod
+++ b/lib/MCP/Server/Tool.rakumod
@@ -169,20 +169,24 @@ class ToolBuilder is export {
         self
     }
 
-    #| Set annotations
+    #| Set annotations (supports both short names and spec names with Hint suffix)
     method annotations(
         Str :$title,
         Bool :$readOnly,
+        Bool :$readOnlyHint,
         Bool :$destructive,
+        Bool :$destructiveHint,
         Bool :$idempotent,
-        Bool :$openWorld
+        Bool :$idempotentHint,
+        Bool :$openWorld,
+        Bool :$openWorldHint
     --> ToolBuilder) {
         $!annotations = MCP::Types::ToolAnnotations.new(
             title => $title,
-            readOnlyHint => $readOnly,
-            destructiveHint => $destructive,
-            idempotentHint => $idempotent,
-            openWorldHint => $openWorld,
+            readOnlyHint => $readOnly // $readOnlyHint,
+            destructiveHint => $destructive // $destructiveHint,
+            idempotentHint => $idempotent // $idempotentHint,
+            openWorldHint => $openWorld // $openWorldHint,
         );
         self
     }

--- a/t/03-builders.rakutest
+++ b/t/03-builders.rakutest
@@ -42,6 +42,17 @@ subtest 'Tool builder and normalization', {
     my $tool = $built.to-tool;
     is $tool.name, 'calc', 'to-tool preserves name';
     is $tool.annotations.title, 'Calc', 'annotations set';
+    ok $tool.annotations.readOnlyHint, 'readOnly annotation set';
+    ok $tool.annotations.idempotentHint, 'idempotent annotation set';
+
+    # Test spec-style naming with *Hint suffixes
+    my $spec-style = tool()
+        .name('delete')
+        .annotations(destructiveHint => True, readOnlyHint => False)
+        .handler(-> { 'ok' })
+        .build;
+    ok $spec-style.to-tool.annotations.destructiveHint, 'destructiveHint naming works';
+    nok $spec-style.to-tool.annotations.readOnlyHint, 'readOnlyHint naming works';
 
     my $result = $built.call({ a => 'x' });
     isa-ok $result, MCP::Types::CallToolResult, 'call returns CallToolResult';
@@ -88,6 +99,17 @@ subtest 'Resource builder and normalization', {
 
     is $resource.to-resource.uri, 'info://test', 'resource uri';
     is $resource.to-resource.name, 'Test', 'resource name';
+
+    # Test resource annotations
+    my $res-obj = $resource.to-resource;
+    ok $res-obj.annotations.defined, 'resource annotations set';
+    is $res-obj.annotations.audience[0], 'user', 'resource audience set';
+    is $res-obj.annotations.priority, 0.5, 'resource priority set';
+
+    # Test annotations in Hash serialization
+    my %res-hash = $res-obj.Hash;
+    ok %res-hash<annotations>:exists, 'annotations in resource Hash';
+    is %res-hash<annotations><priority>, 0.5, 'priority in serialized Hash';
 
     my $contents = $resource.read;
     is $contents[0].text, 'hello', 'string normalized to ResourceContents';

--- a/t/05-server.rakutest
+++ b/t/05-server.rakutest
@@ -304,6 +304,106 @@ subtest 'Cancellation support', {
     @notifications = $transport.sent.grep(MCP::JSONRPC::Notification);
     is @notifications.elems, 1, 'cancel-request without reason sends notification';
     nok @notifications[0].params<reason>:exists, 'notification has no reason when not provided';
+
+    # Test cancellation of in-flight request suppresses response
+    # Use a Promise-based handler that we can control
+    my $handler-promise = Promise.new;
+    my $handler-vow = $handler-promise.vow;
+
+    my $server2 = Server.new(
+        info => MCP::Types::Implementation.new(name => 'srv2', version => '0.1'),
+        transport => $transport
+    );
+    $server2.add-tool(
+        name => 'slow-tool',
+        description => 'A slow tool for testing cancellation',
+        handler => -> {
+            await $handler-promise;  # Wait until we signal completion
+            'completed'
+        }
+    );
+
+    $transport.clear-sent;
+
+    # Start request processing in background
+    my $request-task = start {
+        $server2.handle-message-public(MCP::JSONRPC::Request.new(
+            id => 'cancel-test-1',
+            method => 'tools/call',
+            params => { name => 'slow-tool', arguments => {} }
+        ));
+    };
+
+    # Give the handler time to start
+    sleep 0.1;
+
+    # Verify request is tracked as in-flight
+    ok $server2.is-cancelled('cancel-test-1') === False, 'in-flight request is tracked';
+
+    # Send cancellation while handler is running
+    $server2.handle-message-public(MCP::JSONRPC::Notification.new(
+        method => 'notifications/cancelled',
+        params => { requestId => 'cancel-test-1', reason => 'test cancellation' }
+    ));
+
+    # Verify request is now marked as cancelled
+    ok $server2.is-cancelled('cancel-test-1'), 'is-cancelled returns True after cancellation';
+
+    # Complete the handler
+    $handler-vow.keep(True);
+    await $request-task;
+
+    # Verify no response was sent (key behavior!)
+    my @responses = $transport.sent.grep(MCP::JSONRPC::Response);
+    is @responses.elems, 0, 'cancelled request does not send response';
+};
+
+subtest 'Annotations in list responses', {
+    my $transport = TestTransport::TestTransport.new;
+    my $server = Server.new(
+        info => MCP::Types::Implementation.new(name => 'srv', version => '0.1'),
+        transport => $transport
+    );
+
+    # Add tool with annotations
+    $server.add-tool(
+        MCP::Server::Tool::tool()
+            .name('delete-file')
+            .description('Delete a file')
+            .annotations(destructiveHint => True, readOnlyHint => False, title => 'File Deleter')
+            .handler(-> { 'deleted' })
+            .build
+    );
+
+    # Add resource with annotations
+    $server.add-resource(
+        MCP::Server::Resource::resource()
+            .uri('info://config')
+            .name('Config')
+            .description('Configuration')
+            .annotations(['user', 'assistant'], priority => 0.8)
+            .reader(-> { 'config data' })
+            .build
+    );
+
+    # Verify tool annotations in tools/list response
+    my $tools = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 1,
+        method => 'tools/list'
+    ));
+    ok $tools<tools>[0]<annotations>:exists, 'tool annotations in list response';
+    is $tools<tools>[0]<annotations><title>, 'File Deleter', 'tool title annotation';
+    ok $tools<tools>[0]<annotations><destructiveHint>, 'tool destructiveHint annotation';
+    nok $tools<tools>[0]<annotations><readOnlyHint>, 'tool readOnlyHint annotation';
+
+    # Verify resource annotations in resources/list response
+    my $resources = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 2,
+        method => 'resources/list'
+    ));
+    ok $resources<resources>[0]<annotations>:exists, 'resource annotations in list response';
+    is $resources<resources>[0]<annotations><priority>, 0.8, 'resource priority annotation';
+    is-deeply $resources<resources>[0]<annotations><audience>, ['user', 'assistant'], 'resource audience annotation';
 };
 
 done-testing;


### PR DESCRIPTION
## Summary
The types for annotations exist but aren't exposed through the builder APIs.

## Current State
- `ToolAnnotations` class exists with `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`
- `Annotations` class exists with `audience`, `priority`
- Neither is accessible via the fluent builder pattern

## Requirements
- Add `.annotations()` method to `ToolBuilder`
- Add `.annotations()` method to `ResourceBuilder`
- Ensure annotations are serialized in `tools/list` and `resources/list` responses

## Example API
```raku
tool()
  .name('delete-file')
  .description('Delete a file')
  .annotations(destructiveHint => True, readOnlyHint => False)
  .handler(&delete-handler)
  .build;
```