### PR TITLE
Resource subscriptions

### DIFF
--- a/GAP_ANALYSIS.md
+++ b/GAP_ANALYSIS.md
@@ -79,9 +79,9 @@ This document compares the current implementation of the Raku MCP SDK against th
 
 **Missing**:
 - ❌ Resource templates (URI templates with placeholders)
-- ❌ Resource subscriptions (`resources/subscribe`, `resources/unsubscribe`)
-- ❌ `notifications/resources/list_changed`
-- ❌ `notifications/resources/updated` for subscribed resources
+- ✅ Resource subscriptions (`resources/subscribe`, `resources/unsubscribe`) - **Implemented**
+- ✅ `notifications/resources/list_changed` - **Implemented** via `notify-resources-list-changed()`
+- ✅ `notifications/resources/updated` for subscribed resources - **Implemented** via `notify-resource-updated(uri)`
 - ✅ `resources/list` pagination support - **Implemented**
 - ✅ Resource annotations (`audience`, `priority`) - **Implemented** via builder API
 
@@ -210,8 +210,8 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 
 | Feature | Python SDK | Raku SDK |
 |---------|-----------|----------|
-| Tools | ✅ Full | ⚠️ Basic |
-| Resources | ✅ Full + templates + subscriptions | ⚠️ Basic |
+| Tools | ✅ Full | ⚠️ Basic + annotations |
+| Resources | ✅ Full + templates + subscriptions | ✅ Full + subscriptions (no templates) |
 | Prompts | ✅ Full | ⚠️ Basic |
 | Sampling | ✅ Full + tools | ⚠️ Basic |
 | Roots | ✅ Full | ❌ No |
@@ -229,7 +229,7 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 
 ### High Priority (Core Functionality)
 1. **Complete Streamable HTTP transport** - Required for remote deployments
-2. **Add resource subscriptions** - Common use case for file watching
+2. ~~**Add resource subscriptions**~~ ✅ **Done** - Subscribe/unsubscribe and update notifications
 3. ~~**Add pagination**~~ ✅ **Done** - Cursor-based pagination for all list endpoints
 4. **Implement roots** - Required for filesystem-based servers
 5. ~~**Implement proper cancellation**~~ ✅ **Done** - Request cancellation with notifications
@@ -283,7 +283,7 @@ Current tests cover:
 - ✅ Sampling validation
 
 Missing tests for:
-- ❌ Resource subscriptions
+- ✅ Resource subscriptions - **Implemented**
 - ✅ Pagination - **Implemented**
 - ✅ Cancellation - **Implemented**
 - ❌ Progress tracking
@@ -298,8 +298,8 @@ Missing tests for:
 The Raku MCP SDK provides a solid foundation with core protocol support, but significant work remains to achieve full specification compliance. The highest impact improvements would be:
 
 1. Completing HTTP transport for production deployment
-2. Adding resource subscriptions for real-time updates
-3. Implementing pagination for scalability
+2. ~~Adding resource subscriptions for real-time updates~~ ✅ **Done**
+3. ~~Implementing pagination for scalability~~ ✅ **Done**
 4. Adding roots support for filesystem servers
 5. Implementing the authorization framework for secure connections
 

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "perl": "6.d",
     "auth": "github:wkusnierczyk",
     "license": "MIT",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.4.0
+VERSION         := 0.5.0
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk

--- a/t/05-server.rakutest
+++ b/t/05-server.rakutest
@@ -568,6 +568,48 @@ subtest 'Resource subscriptions', {
     @notifications = $transport.sent.grep(MCP::JSONRPC::Notification);
     is @notifications.elems, 1, 'notify-resources-list-changed sends notification';
     is @notifications[0].method, 'notifications/resources/list_changed', 'list changed notification method is correct';
+
+    # Test multiple subscriptions
+    $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 8,
+        method => 'resources/subscribe',
+        params => { uri => 'file://test.txt' }
+    ));
+    $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 9,
+        method => 'resources/subscribe',
+        params => { uri => 'file://other.txt' }
+    ));
+    ok $server.is-subscribed('file://test.txt'), 'first resource still subscribed';
+    ok $server.is-subscribed('file://other.txt'), 'second resource now subscribed';
+
+    # Test notifications sent only for subscribed resources when multiple subscribed
+    $transport.clear-sent;
+    $server.notify-resource-updated('file://test.txt');
+    $server.notify-resource-updated('file://other.txt');
+    @notifications = $transport.sent.grep(MCP::JSONRPC::Notification);
+    is @notifications.elems, 2, 'both subscribed resources get notifications';
+
+    # Test idempotent subscribe (subscribing twice should succeed)
+    lives-ok {
+        $server.dispatch-request(MCP::JSONRPC::Request.new(
+            id => 10,
+            method => 'resources/subscribe',
+            params => { uri => 'file://test.txt' }
+        ));
+    }, 'subscribing twice succeeds (idempotent)';
+    ok $server.is-subscribed('file://test.txt'), 'still subscribed after double subscribe';
+
+    # Test is-subscribed for completely unknown URI
+    nok $server.is-subscribed('file://never-existed.txt'), 'is-subscribed returns false for unknown URI';
+
+    # Test notify-resource-updated for unknown URI (should not send, not throw)
+    $transport.clear-sent;
+    lives-ok {
+        $server.notify-resource-updated('file://unknown-resource.txt');
+    }, 'notify-resource-updated for unknown URI does not throw';
+    @notifications = $transport.sent.grep(MCP::JSONRPC::Notification);
+    is @notifications.elems, 0, 'no notification sent for unknown URI';
 };
 
 done-testing;

--- a/t/05-server.rakutest
+++ b/t/05-server.rakutest
@@ -458,4 +458,116 @@ subtest 'Annotations in list responses', {
     is-deeply $resources<resources>[0]<annotations><audience>, ['user', 'assistant'], 'resource audience annotation';
 };
 
+subtest 'Resource subscriptions', {
+    my $transport = TestTransport::TestTransport.new;
+    my $server = Server.new(
+        info => MCP::Types::Implementation.new(name => 'srv', version => '0.1'),
+        transport => $transport
+    );
+
+    # Add resources to subscribe to
+    $server.add-resource(
+        uri => 'file://test.txt',
+        name => 'Test File',
+        reader => { 'content' }
+    );
+    $server.add-resource(
+        uri => 'file://other.txt',
+        name => 'Other File',
+        reader => { 'other content' }
+    );
+
+    # Verify capabilities include subscribe
+    my $init = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 1,
+        method => 'initialize',
+        params => { protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION }
+    ));
+    ok $init<capabilities><resources><subscribe>, 'capabilities include subscribe';
+
+    # Test subscribe to resource
+    my $sub-result = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 2,
+        method => 'resources/subscribe',
+        params => { uri => 'file://test.txt' }
+    ));
+    is-deeply $sub-result, {}, 'subscribe returns empty response';
+
+    # Verify resource is subscribed
+    ok $server.is-subscribed('file://test.txt'), 'resource is marked as subscribed';
+    nok $server.is-subscribed('file://other.txt'), 'other resource is not subscribed';
+
+    # Test subscribe requires uri
+    dies-ok {
+        $server.dispatch-request(MCP::JSONRPC::Request.new(
+            id => 3,
+            method => 'resources/subscribe',
+            params => {}
+        ));
+    }, 'subscribe requires uri parameter';
+
+    # Test subscribe to unknown resource
+    dies-ok {
+        $server.dispatch-request(MCP::JSONRPC::Request.new(
+            id => 4,
+            method => 'resources/subscribe',
+            params => { uri => 'file://nonexistent.txt' }
+        ));
+    }, 'subscribe to unknown resource fails';
+
+    # Test notify-resource-updated sends notification for subscribed resource
+    $transport.clear-sent;
+    $server.notify-resource-updated('file://test.txt');
+    my @notifications = $transport.sent.grep(MCP::JSONRPC::Notification);
+    is @notifications.elems, 1, 'notify-resource-updated sends notification';
+    is @notifications[0].method, 'notifications/resources/updated', 'notification method is correct';
+    is @notifications[0].params<uri>, 'file://test.txt', 'notification has correct uri';
+
+    # Test notify-resource-updated does NOT send for unsubscribed resource
+    $transport.clear-sent;
+    $server.notify-resource-updated('file://other.txt');
+    @notifications = $transport.sent.grep(MCP::JSONRPC::Notification);
+    is @notifications.elems, 0, 'no notification for unsubscribed resource';
+
+    # Test unsubscribe
+    my $unsub-result = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 5,
+        method => 'resources/unsubscribe',
+        params => { uri => 'file://test.txt' }
+    ));
+    is-deeply $unsub-result, {}, 'unsubscribe returns empty response';
+    nok $server.is-subscribed('file://test.txt'), 'resource is no longer subscribed';
+
+    # Test notify-resource-updated after unsubscribe
+    $transport.clear-sent;
+    $server.notify-resource-updated('file://test.txt');
+    @notifications = $transport.sent.grep(MCP::JSONRPC::Notification);
+    is @notifications.elems, 0, 'no notification after unsubscribe';
+
+    # Test unsubscribe requires uri
+    dies-ok {
+        $server.dispatch-request(MCP::JSONRPC::Request.new(
+            id => 6,
+            method => 'resources/unsubscribe',
+            params => {}
+        ));
+    }, 'unsubscribe requires uri parameter';
+
+    # Test unsubscribe from unknown resource (should succeed silently)
+    lives-ok {
+        $server.dispatch-request(MCP::JSONRPC::Request.new(
+            id => 7,
+            method => 'resources/unsubscribe',
+            params => { uri => 'file://never-subscribed.txt' }
+        ));
+    }, 'unsubscribe from unknown resource succeeds';
+
+    # Test notify-resources-list-changed
+    $transport.clear-sent;
+    $server.notify-resources-list-changed();
+    @notifications = $transport.sent.grep(MCP::JSONRPC::Notification);
+    is @notifications.elems, 1, 'notify-resources-list-changed sends notification';
+    is @notifications[0].method, 'notifications/resources/list_changed', 'list changed notification method is correct';
+};
+
 done-testing;

--- a/t/06-client.rakutest
+++ b/t/06-client.rakutest
@@ -246,4 +246,72 @@ subtest 'Client cancellation support', {
     ok $cancel-notif.defined, 'notifications/cancelled was sent';
 };
 
+subtest 'Client resource subscription support', {
+    my $transport = TestTransport::TestTransport.new;
+    my $client = Client.new(
+        info => MCP::Types::Implementation.new(name => 'cli', version => '0.1'),
+        transport => $transport
+    );
+
+    my $connect = $client.connect;
+    for ^10 {
+        last if $transport.sent.elems > 0;
+        sleep 0.1;
+    }
+    my $init-req = $transport.sent[0];
+    $transport.emit(MCP::JSONRPC::Response.success($init-req.id, {
+        protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
+        capabilities => { resources => { subscribe => True } },
+        instructions => 'test'
+    }));
+    await $connect;
+
+    # Test subscribe-resource sends request
+    $transport.clear-sent;
+    my $sub-p = $client.subscribe-resource('file://test.txt');
+    my $sub-req = $transport.sent.grep(MCP::JSONRPC::Request)[*-1];
+    is $sub-req.method, 'resources/subscribe', 'subscribe-resource sends correct method';
+    is $sub-req.params<uri>, 'file://test.txt', 'subscribe-resource sends correct uri';
+    respond-to-last($transport, {});
+    await $sub-p;
+    pass 'subscribe-resource completes successfully';
+
+    # Test unsubscribe-resource sends request
+    $transport.clear-sent;
+    my $unsub-p = $client.unsubscribe-resource('file://test.txt');
+    my $unsub-req = $transport.sent.grep(MCP::JSONRPC::Request)[*-1];
+    is $unsub-req.method, 'resources/unsubscribe', 'unsubscribe-resource sends correct method';
+    is $unsub-req.params<uri>, 'file://test.txt', 'unsubscribe-resource sends correct uri';
+    respond-to-last($transport, {});
+    await $unsub-p;
+    pass 'unsubscribe-resource completes successfully';
+
+    # Test receiving resource update notification
+    my $update-received = Promise.new;
+    $client.notifications.tap(-> $n {
+        if $n.method eq 'notifications/resources/updated' {
+            $update-received.keep($n);
+        }
+    });
+    $transport.emit(MCP::JSONRPC::Notification.new(
+        method => 'notifications/resources/updated',
+        params => { uri => 'file://test.txt' }
+    ));
+    my $notif = await $update-received;
+    is $notif.params<uri>, 'file://test.txt', 'resource update notification received';
+
+    # Test receiving list changed notification
+    my $list-changed = Promise.new;
+    $client.notifications.tap(-> $n {
+        if $n.method eq 'notifications/resources/list_changed' {
+            $list-changed.keep($n);
+        }
+    });
+    $transport.emit(MCP::JSONRPC::Notification.new(
+        method => 'notifications/resources/list_changed'
+    ));
+    await $list-changed;
+    pass 'resources list changed notification received';
+};
+
 done-testing;


### PR DESCRIPTION
## Summary
Add support for clients subscribing to resource changes.

## Requirements

### Server Side
- Handle `resources/subscribe` request
- Handle `resources/unsubscribe` request
- Track subscribed resources per client/session
- Send `notifications/resources/updated` when subscribed resources change
- Send `notifications/resources/list_changed` when resource list changes

### Client Side
- Add `subscribe-resource(uri)` method
- Add `unsubscribe-resource(uri)` method
- Handle incoming update notifications
- Expose subscription events via Supply

### Capability
- Set `resources.subscribe = True` in server capabilities

## References
- [MCP Specification - Resources](https://modelcontextprotocol.io/specification/2025-11-25/server/resources)