### PR TITLE
Fix flaky tests

### DIFF
--- a/t/08-sampling.rakutest
+++ b/t/08-sampling.rakutest
@@ -56,10 +56,11 @@ subtest 'Sampling handler returns result', {
     );
 
     my $connect = $client.connect;
-    for ^10 {
+    for ^20 {
         last if $transport.sent.elems > 0;
         sleep 0.1;
     }
+    sleep 0.2;  # Allow message handler to start
     respond-to-init($transport);
     await $connect;
 
@@ -102,10 +103,11 @@ subtest 'Sampling rejects tools when capability missing', {
     );
 
     my $connect = $client.connect;
-    for ^10 {
+    for ^20 {
         last if $transport.sent.elems > 0;
         sleep 0.1;
     }
+    sleep 0.2;  # Allow message handler to start
     respond-to-init($transport);
     await $connect;
 
@@ -143,10 +145,11 @@ subtest 'Sampling enforces tool result placement', {
     );
 
     my $connect = $client.connect;
-    for ^10 {
+    for ^20 {
         last if $transport.sent.elems > 0;
         sleep 0.1;
     }
+    sleep 0.2;  # Allow message handler to start
     respond-to-init($transport);
     await $connect;
 


### PR DESCRIPTION
The tests were flaky because they sent the initialize response immediately after detecting the request, but the client's message handler (react { whenever ... }) might not have started listening yet.

Added a small delay after detecting the request to ensure the message handler is ready to receive the response.