### PR TITLE
Implement elicitation support

### DIFF
--- a/GAP_ANALYSIS.md
+++ b/GAP_ANALYSIS.md
@@ -16,7 +16,7 @@ This document compares the current implementation of the Raku MCP SDK against th
 | **Client Features** | ⚠️ Partial | Sampling basic support |
 | **Utilities** | ⚠️ Partial | Logging, progress, cancellation implemented |
 | **Authorization** | ❌ Missing | OAuth 2.1 not implemented |
-| **New 2025-11-25 Features** | ❌ Missing | Tasks, Extensions, URL Elicitation |
+| **New 2025-11-25 Features** | ⚠️ Partial | Elicitation done, Tasks/Extensions missing |
 
 ---
 
@@ -116,12 +116,18 @@ This document compares the current implementation of the Raku MCP SDK against th
 - Server-side:
   - `list-roots()` method to request roots from client
 
-#### ❌ Elicitation (2025-06-18 feature)
-- `ElicitationCapability` type exists but not implemented
-- Missing:
-  - `elicitation/create` request (server → client)
-  - Schema-based user input collection
-  - URL mode elicitation (SEP-1036) for OAuth flows
+#### ✅ Elicitation (2025-06-18 feature)
+- `ElicitationCapability` with form/url mode support
+- `ElicitationAction` enum (accept/decline/cancel)
+- `ElicitationResponse` type with content
+- Server-side:
+  - `elicit(message, schema)` for form mode requests
+  - `elicit-url(message, url, elicitation-id)` for URL mode
+  - `notify-elicitation-complete(elicitation-id)` for completion
+- Client-side:
+  - `elicitation-handler` callback for handling requests
+  - Capability negotiation with form/url modes
+  - `URLElicitationRequired` error code (-32042)
 
 ---
 
@@ -197,9 +203,10 @@ Long-running operation support:
 - SEP-1046: OAuth client credentials (M2M)
 - SEP-990: Enterprise IdP policy controls
 
-#### ❌ URL Mode Elicitation (SEP-1036)
-- Browser-based credential collection
-- Out-of-band OAuth flows
+#### ✅ URL Mode Elicitation (SEP-1036)
+- `elicit-url()` method for URL mode requests
+- `notify-elicitation-complete()` for completion notifications
+- `URLElicitationRequired` error code (-32042)
 
 #### ❌ Sampling with Tools (SEP-1577)
 - Tool definitions in sampling requests
@@ -218,7 +225,7 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 | Prompts | ✅ Full | ⚠️ Basic |
 | Sampling | ✅ Full + tools | ⚠️ Basic |
 | Roots | ✅ Full | ✅ Full |
-| Elicitation | ✅ Full + URL mode | ❌ No |
+| Elicitation | ✅ Full + URL mode | ✅ Full |
 | OAuth 2.1 | ✅ Full | ❌ No |
 | Streamable HTTP | ✅ Full client + server | ✅ Full |
 | SSE Transport | ✅ Full | ❌ No |
@@ -239,26 +246,14 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 
 ### Medium Priority (Enhanced Functionality)
 6. **Add tool output schemas** - Better structured responses
-7. **Implement elicitation** - Server-initiated user input
+7. ~~**Implement elicitation**~~ ✅ **Done** - Form and URL mode with handler callbacks
 8. **Add completion/autocomplete** - Better UX for prompt arguments
 9. **Implement OAuth 2.1** - Required for authenticated servers
 
 ### Lower Priority (Advanced Features)
 10. **Tasks framework** - Long-running operations (experimental)
 11. **Extensions framework** - Plugin architecture
-12. **URL mode elicitation** - Advanced OAuth flows
-13. **Sampling with tools** - Advanced agentic capabilities
-
----
-
-## Type System Gaps
-
-The following types are defined but not fully utilized:
-
-```raku
-# Defined but unused/incomplete:
-- ElicitationCapability - defined, not implemented
-```
+12. **Sampling with tools** - Advanced agentic capabilities
 
 ---
 

--- a/GAP_ANALYSIS.md
+++ b/GAP_ANALYSIS.md
@@ -20,9 +20,28 @@ This document compares the current implementation of the Raku MCP SDK against th
 
 ---
 
+## Table of Contents
+
+- [Detailed Analysis](#detailed-analysis)
+  - [Base Protocol](#base-protocol)
+  - [Transports](#transports)
+  - [Server Features](#server-features)
+  - [Client Features](#client-features)
+  - [Utilities](#utilities)
+  - [Authorization (2025-03-26+)](#authorization-2025-03-26)
+  - [New Features in 2025-11-25](#new-features-in-2025-11-25)
+  - [Comparison with Python SDK](#comparison-with-python-sdk)
+- [Priority Recommendations](#priority-recommendations)
+  - [High Priority (Core Functionality)](#high-priority-core-functionality)
+  - [Medium Priority (Enhanced Functionality)](#medium-priority-enhanced-functionality)
+  - [Lower Priority (Advanced Features)](#lower-priority-advanced-features)
+- [Protocol Version](#protocol-version)
+- [Test Coverage Gaps](#test-coverage-gaps)
+- [Conclusion](#conclusion)
+
 ## Detailed Analysis
 
-### 1. Base Protocol
+### Base Protocol
 
 #### ✅ Implemented
 - JSON-RPC 2.0 message format (`MCP::JSONRPC`)
@@ -40,7 +59,7 @@ This document compares the current implementation of the Raku MCP SDK against th
 
 ---
 
-### 2. Transports
+### Transports
 
 #### ✅ Stdio Transport (`MCP::Transport::Stdio`)
 - Complete implementation
@@ -60,7 +79,7 @@ This document compares the current implementation of the Raku MCP SDK against th
 
 ---
 
-### 3. Server Features
+### Server Features
 
 #### ✅ Tools (`MCP::Server::Tool`)
 - Tool registration with name, description, schema
@@ -95,7 +114,7 @@ This document compares the current implementation of the Raku MCP SDK against th
 
 ---
 
-### 4. Client Features
+### Client Features
 
 #### ⚠️ Sampling (`MCP::Client` sampling-handler)
 - Basic `sampling/createMessage` handling
@@ -131,7 +150,7 @@ This document compares the current implementation of the Raku MCP SDK against th
 
 ---
 
-### 5. Utilities
+### Utilities
 
 #### ⚠️ Progress Tracking
 - `progress()` method exists on Server
@@ -170,7 +189,7 @@ This document compares the current implementation of the Raku MCP SDK against th
 
 ---
 
-### 6. Authorization (2025-03-26+)
+### Authorization (2025-03-26+)
 
 #### ❌ Not Implemented
 The entire authorization framework is missing:
@@ -184,7 +203,7 @@ The entire authorization framework is missing:
 
 ---
 
-### 7. New Features in 2025-11-25
+### New Features in 2025-11-25
 
 #### ❌ Tasks (Experimental)
 Long-running operation support:

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "perl": "6.d",
     "auth": "github:wkusnierczyk",
     "license": "MIT",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.7.0
+VERSION         := 0.8.0
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See [Gap Analysis](GAP_ANALYSIS.md) for details on implemented and missing featu
 | Roots | ✅ Done | Client roots, server list-roots |
 | Sampling | ⚠️ Partial | Basic support, missing tools/toolChoice/includeContext/stopReason |
 | HTTP Transport | ✅ Done | Full client/server with session management, SSE, resumption |
-| Elicitation | ❌ Planned | Client-side support incl. URL mode |
+| Elicitation | ✅ Done | Form and URL modes with handler callbacks |
 | Tasks (experimental) | ❌ Planned | |
 | Extensions framework | ❌ Planned | |
 | Completion | ❌ Planned | Autocomplete/complete endpoints |

--- a/lib/MCP/JSONRPC.rakumod
+++ b/lib/MCP/JSONRPC.rakumod
@@ -27,11 +27,12 @@ use JSON::Fast;
 
 #| Standard JSON-RPC 2.0 error codes
 enum ErrorCode is export (
-    ParseError      => -32700,
-    InvalidRequest  => -32600,
-    MethodNotFound  => -32601,
-    InvalidParams   => -32602,
-    InternalError   => -32603,
+    ParseError              => -32700,
+    InvalidRequest          => -32600,
+    MethodNotFound          => -32601,
+    InvalidParams           => -32602,
+    InternalError           => -32603,
+    URLElicitationRequired  => -32042,
 );
 
 #| Base role for all JSON-RPC messages
@@ -69,12 +70,13 @@ class Error is export {
     #| Create an Error from a standard JSON-RPC error code
     method from-code(ErrorCode $code, Str $message?, :$data --> Error) {
         my $msg = $message // do given $code {
-            when ParseError     { 'Parse error' }
-            when InvalidRequest { 'Invalid request' }
-            when MethodNotFound { 'Method not found' }
-            when InvalidParams  { 'Invalid params' }
-            when InternalError  { 'Internal error' }
-            default             { 'Unknown error' }
+            when ParseError              { 'Parse error' }
+            when InvalidRequest          { 'Invalid request' }
+            when MethodNotFound          { 'Method not found' }
+            when InvalidParams           { 'Invalid params' }
+            when InternalError           { 'Internal error' }
+            when URLElicitationRequired  { 'URL elicitation required' }
+            default                      { 'Unknown error' }
         };
         self.new(code => $code.value, message => $msg, :$data)
     }

--- a/lib/MCP/Server.rakumod
+++ b/lib/MCP/Server.rakumod
@@ -567,4 +567,38 @@ class Server is export {
             }).Array
         })
     }
+
+    #| Request user input via form mode elicitation
+    #| Returns a Promise that resolves to an ElicitationResponse
+    method elicit(Str :$message!, :%schema! --> Promise) {
+        self.request('elicitation/create', {
+            mode => 'form',
+            message => $message,
+            requestedSchema => %schema,
+        }).then(-> $p {
+            my $result = $p.result;
+            MCP::Types::ElicitationResponse.from-hash($result)
+        })
+    }
+
+    #| Request user interaction via URL mode elicitation
+    #| Returns a Promise that resolves to an ElicitationResponse
+    method elicit-url(Str :$message!, Str :$url!, Str :$elicitation-id! --> Promise) {
+        self.request('elicitation/create', {
+            mode => 'url',
+            message => $message,
+            url => $url,
+            elicitationId => $elicitation-id,
+        }).then(-> $p {
+            my $result = $p.result;
+            MCP::Types::ElicitationResponse.from-hash($result)
+        })
+    }
+
+    #| Notify client that a URL mode elicitation has completed
+    method notify-elicitation-complete(Str $elicitation-id) {
+        self.notify('notifications/elicitation/complete', {
+            elicitationId => $elicitation-id,
+        });
+    }
 }

--- a/t/01-types.rakutest
+++ b/t/01-types.rakutest
@@ -16,7 +16,7 @@ use lib 'lib';
 
 use MCP::Types;
 
-plan 24;
+plan 27;
 
 # Test Implementation
 subtest 'Implementation', {
@@ -300,6 +300,73 @@ subtest 'Root', {
     my $restored = Root.from-hash({ uri => 'file:///restored', name => 'Restored' });
     is $restored.uri, 'file:///restored', 'from-hash restores uri';
     is $restored.name, 'Restored', 'from-hash restores name';
+};
+
+# Test ElicitationAction enum
+subtest 'ElicitationAction', {
+    is ElicitAccept.value, 'accept', 'accept value';
+    is ElicitDecline.value, 'decline', 'decline value';
+    is ElicitCancel.value, 'cancel', 'cancel value';
+};
+
+# Test ElicitationCapability
+subtest 'ElicitationCapability', {
+    # Default (form only)
+    my $cap-default = ElicitationCapability.new;
+    ok $cap-default.supports-form, 'default supports form';
+    nok $cap-default.supports-url, 'default does not support url';
+    my %h-default = $cap-default.Hash;
+    ok %h-default<form>:exists, 'default Hash has form';
+    nok %h-default<url>:exists, 'default Hash has no url';
+
+    # Both modes
+    my $cap-both = ElicitationCapability.new(:form, :url);
+    ok $cap-both.supports-form, 'both supports form';
+    ok $cap-both.supports-url, 'both supports url';
+    my %h-both = $cap-both.Hash;
+    ok %h-both<form>:exists, 'both Hash has form';
+    ok %h-both<url>:exists, 'both Hash has url';
+
+    # from-hash
+    my $from-empty = ElicitationCapability.from-hash({});
+    ok $from-empty.supports-form, 'empty hash defaults to form';
+    nok $from-empty.supports-url, 'empty hash has no url';
+
+    my $from-url = ElicitationCapability.from-hash({ url => {} });
+    ok $from-url.supports-url, 'from-hash with url';
+};
+
+# Test ElicitationResponse
+subtest 'ElicitationResponse', {
+    # Accept with content
+    my $accept = ElicitationResponse.new(
+        action => ElicitAccept,
+        content => { name => 'test', age => 25 }
+    );
+    is $accept.action, ElicitAccept, 'accept action';
+    is $accept.content<name>, 'test', 'accept has content';
+    my %h-accept = $accept.Hash;
+    is %h-accept<action>, 'accept', 'Hash has action';
+    is %h-accept<content><name>, 'test', 'Hash has content';
+
+    # Decline
+    my $decline = ElicitationResponse.new(action => ElicitDecline);
+    is $decline.action, ElicitDecline, 'decline action';
+    my %h-decline = $decline.Hash;
+    is %h-decline<action>, 'decline', 'decline Hash';
+    nok %h-decline<content>:exists, 'decline has no content';
+
+    # Cancel
+    my $cancel = ElicitationResponse.new(action => ElicitCancel);
+    is $cancel.action, ElicitCancel, 'cancel action';
+
+    # from-hash
+    my $restored = ElicitationResponse.from-hash({
+        action => 'accept',
+        content => { email => 'test@example.com' }
+    });
+    is $restored.action, ElicitAccept, 'from-hash restores accept';
+    is $restored.content<email>, 'test@example.com', 'from-hash restores content';
 };
 
 done-testing;

--- a/t/02-jsonrpc.rakutest
+++ b/t/02-jsonrpc.rakutest
@@ -26,6 +26,7 @@ subtest 'Error codes', {
     is MethodNotFound.value, -32601, 'MethodNotFound code';
     is InvalidParams.value, -32602, 'InvalidParams code';
     is InternalError.value, -32603, 'InternalError code';
+    is URLElicitationRequired.value, -32042, 'URLElicitationRequired code';
 };
 
 # Test Error class

--- a/t/05-server.rakutest
+++ b/t/05-server.rakutest
@@ -656,4 +656,72 @@ subtest 'Server list-roots', {
     is @empty-roots.elems, 0, 'empty roots returns empty array';
 };
 
+subtest 'Server elicitation', {
+    my $transport = TestTransport::TestTransport.new;
+    my $server = Server.new(
+        info => MCP::Types::Implementation.new(name => 'test', version => '0.1'),
+        transport => $transport,
+    );
+
+    # Test elicit (form mode)
+    $transport.clear-sent;
+    my $elicit-promise = $server.elicit(
+        message => 'Please enter your name',
+        schema => {
+            type => 'object',
+            properties => {
+                name => { type => 'string' }
+            },
+            required => ['name']
+        }
+    );
+
+    # Verify request was sent
+    my @requests = $transport.sent.grep(MCP::JSONRPC::Request);
+    is @requests.elems, 1, 'elicit sends request';
+    is @requests[0].method, 'elicitation/create', 'request method is elicitation/create';
+    is @requests[0].params<mode>, 'form', 'mode is form';
+    is @requests[0].params<message>, 'Please enter your name', 'message is correct';
+    ok @requests[0].params<requestedSchema>:exists, 'requestedSchema exists';
+
+    # Simulate client response
+    $server.handle-response-public(MCP::JSONRPC::Response.success(@requests[0].id, {
+        action => 'accept',
+        content => { name => 'Alice' }
+    }));
+
+    my $response = await $elicit-promise;
+    isa-ok $response, MCP::Types::ElicitationResponse, 'response is ElicitationResponse';
+    is $response.action, MCP::Types::ElicitAccept, 'action is accept';
+    is $response.content<name>, 'Alice', 'content has name';
+
+    # Test elicit-url (URL mode)
+    $transport.clear-sent;
+    my $url-promise = $server.elicit-url(
+        message => 'Please provide your API key',
+        url => 'https://example.com/auth',
+        elicitation-id => 'test-123'
+    );
+
+    @requests = $transport.sent.grep(MCP::JSONRPC::Request);
+    is @requests.elems, 1, 'elicit-url sends request';
+    is @requests[0].params<mode>, 'url', 'mode is url';
+    is @requests[0].params<url>, 'https://example.com/auth', 'url is correct';
+    is @requests[0].params<elicitationId>, 'test-123', 'elicitationId is correct';
+
+    $server.handle-response-public(MCP::JSONRPC::Response.success(@requests[0].id, {
+        action => 'accept'
+    }));
+    my $url-response = await $url-promise;
+    is $url-response.action, MCP::Types::ElicitAccept, 'URL elicit returns accept';
+
+    # Test notify-elicitation-complete
+    $transport.clear-sent;
+    $server.notify-elicitation-complete('test-123');
+    my @notifications = $transport.sent.grep(MCP::JSONRPC::Notification);
+    is @notifications.elems, 1, 'notification sent';
+    is @notifications[0].method, 'notifications/elicitation/complete', 'notification method';
+    is @notifications[0].params<elicitationId>, 'test-123', 'notification has elicitationId';
+};
+
 done-testing;

--- a/t/06-client.rakutest
+++ b/t/06-client.rakutest
@@ -404,4 +404,110 @@ subtest 'Client roots support', {
     nok $init-req2.params<capabilities><roots>:exists, 'no roots capability without roots';
 };
 
+subtest 'Client elicitation support', {
+    my $transport = TestTransport::TestTransport.new;
+    my $elicit-received = False;
+    my %elicit-params;
+
+    my $client = Client.new(
+        info => MCP::Types::Implementation.new(name => 'cli', version => '0.1'),
+        transport => $transport,
+        elicitation-handler => -> %params {
+            $elicit-received = True;
+            %elicit-params = %params;
+            MCP::Types::ElicitationResponse.new(
+                action => MCP::Types::ElicitAccept,
+                content => { name => 'Test User' }
+            )
+        }
+    );
+
+    my $connect = $client.connect;
+    for ^10 {
+        last if $transport.sent.elems > 0;
+        sleep 0.1;
+    }
+    my $init-req = $transport.sent[0];
+
+    # Verify elicitation capability is advertised
+    ok $init-req.params<capabilities><elicitation>:exists, 'elicitation capability advertised';
+    ok $init-req.params<capabilities><elicitation><form>:exists, 'form mode advertised';
+
+    $transport.emit(MCP::JSONRPC::Response.success($init-req.id, {
+        protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
+        capabilities => {},
+        instructions => 'test'
+    }));
+    await $connect;
+
+    # Send elicitation request from server
+    $transport.clear-sent;
+    $transport.emit(MCP::JSONRPC::Request.new(
+        id => 100,
+        method => 'elicitation/create',
+        params => {
+            mode => 'form',
+            message => 'Enter your name',
+            requestedSchema => {
+                type => 'object',
+                properties => { name => { type => 'string' } },
+                required => ['name']
+            }
+        }
+    ));
+
+    # Wait for response
+    for ^10 {
+        last if $transport.sent.elems > 0;
+        sleep 0.1;
+    }
+
+    ok $elicit-received, 'elicitation handler was called';
+    is %elicit-params<message>, 'Enter your name', 'handler received message';
+    is %elicit-params<mode>, 'form', 'handler received mode';
+
+    my @responses = $transport.sent.grep(MCP::JSONRPC::Response);
+    is @responses.elems, 1, 'response sent';
+    is @responses[0].id, 100, 'response has correct id';
+    is @responses[0].result<action>, 'accept', 'response action is accept';
+    is @responses[0].result<content><name>, 'Test User', 'response has content';
+
+    # Test client without handler rejects elicitation
+    my $client2 = Client.new(
+        info => MCP::Types::Implementation.new(name => 'cli2', version => '0.1'),
+        transport => TestTransport::TestTransport.new
+    );
+    my $connect2 = $client2.connect;
+    for ^10 {
+        last if $client2.transport.sent.elems > 0;
+        sleep 0.1;
+    }
+    my $init2 = $client2.transport.sent[0];
+    nok $init2.params<capabilities><elicitation>:exists, 'no elicitation without handler';
+
+    $client2.transport.emit(MCP::JSONRPC::Response.success($init2.id, {
+        protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
+        capabilities => {},
+        instructions => 'test'
+    }));
+    await $connect2;
+
+    $client2.transport.clear-sent;
+    $client2.transport.emit(MCP::JSONRPC::Request.new(
+        id => 200,
+        method => 'elicitation/create',
+        params => { mode => 'form', message => 'test' }
+    ));
+
+    for ^10 {
+        last if $client2.transport.sent.elems > 0;
+        sleep 0.1;
+    }
+
+    @responses = $client2.transport.sent.grep(MCP::JSONRPC::Response);
+    is @responses.elems, 1, 'error response sent';
+    ok @responses[0].error.defined, 'response has error';
+    is @responses[0].error.code, MCP::JSONRPC::MethodNotFound.value, 'error is MethodNotFound';
+};
+
 done-testing;


### PR DESCRIPTION
**Implement elicitation support**

- Add ElicitationAction enum (accept/decline/cancel) and
  ElicitationResponse type with form content support
- Expand ElicitationCapability with form/url mode negotiation
- Add URLElicitationRequired error code (-32042) to JSONRPC
- Server: add elicit(), elicit-url(), and notify-elicitation-complete()
- Client: add elicitation-handler callback, handle elicitation/create
  requests, advertise elicitation capability during initialization
- Add comprehensive tests for types, server, and client elicitation
- Update GAP_ANALYSIS.md and README.md