### PR TITLE
Implement completion/autocomplete support

### DIFF
--- a/GAP_ANALYSIS.md
+++ b/GAP_ANALYSIS.md
@@ -180,12 +180,13 @@ This document compares the current implementation of the Raku MCP SDK against th
   - Client-side `ping` for keepalive
   - Timeout handling
 
-#### ❌ Completion (autocomplete)
-- Not implemented
-- Missing:
-  - `completion/complete` request
-  - Argument completion for prompts
-  - Resource URI completion
+#### ✅ Completion (autocomplete)
+- `completion/complete` request handling
+- Server: `add-prompt-completer()`, `add-resource-completer()` for registering completers
+- Client: `complete-prompt()`, `complete-resource()` convenience methods
+- `CompletionResult` type with values, total, hasMore
+- Auto-truncation to 100 values per spec
+- `completions` capability advertised when completers registered
 
 ---
 
@@ -266,7 +267,7 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 ### Medium Priority (Enhanced Functionality)
 6. **Add tool output schemas** - Better structured responses
 7. ~~**Implement elicitation**~~ ✅ **Done** - Form and URL mode with handler callbacks
-8. **Add completion/autocomplete** - Better UX for prompt arguments
+8. ~~**Add completion/autocomplete**~~ ✅ **Done** - Prompt and resource completion with handler registration
 9. **Implement OAuth 2.1** - Required for authenticated servers
 
 ### Lower Priority (Advanced Features)

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "perl": "6.d",
     "auth": "github:wkusnierczyk",
     "license": "MIT",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.8.0
+VERSION         := 0.9.0
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Gap Analysis](GAP_ANALYSIS.md) for details on implemented and missing featu
 | Elicitation | ✅ Done | Form and URL modes with handler callbacks |
 | Tasks (experimental) | ❌ Planned | |
 | Extensions framework | ❌ Planned | |
-| Completion | ❌ Planned | Autocomplete/complete endpoints |
+| Completion | ✅ Done | Prompt and resource autocomplete with handler registration |
 | Tool output schemas | ❌ Planned | `outputSchema` for structured tool results |
 | Tool metadata | ❌ Planned | icon metadata + tool name validation guidance |
 | OAuth 2.1 | ❌ Planned | OIDC discovery, incremental consent, client ID metadata |

--- a/lib/MCP/Client.rakumod
+++ b/lib/MCP/Client.rakumod
@@ -288,6 +288,26 @@ class Client is export {
         })
     }
 
+    #| Request completion for a prompt argument
+    method complete-prompt(Str $prompt-name, Str :$argument-name!, Str :$value! --> Promise) {
+        self.request('completion/complete', {
+            ref => { type => 'ref/prompt', name => $prompt-name },
+            argument => { name => $argument-name, value => $value },
+        }).then(-> $promise {
+            MCP::Types::CompletionResult.from-hash($promise.result<completion> // {})
+        })
+    }
+
+    #| Request completion for a resource URI
+    method complete-resource(Str $uri, Str :$argument-name!, Str :$value! --> Promise) {
+        self.request('completion/complete', {
+            ref => { type => 'ref/resource', uri => $uri },
+            argument => { name => $argument-name, value => $value },
+        }).then(-> $promise {
+            MCP::Types::CompletionResult.from-hash($promise.result<completion> // {})
+        })
+    }
+
     #| Ping the server
     method ping(--> Promise) {
         self.request('ping').then({ True })

--- a/lib/MCP/Types.rakumod
+++ b/lib/MCP/Types.rakumod
@@ -432,6 +432,32 @@ class ToolsCapability is export {
     }
 }
 
+class CompletionsCapability is export {
+    method Hash(--> Hash) { {} }
+}
+
+#| Completion result from server
+class CompletionResult is export {
+    has @.values;  # Array of Str, max 100
+    has Int $.total;
+    has Bool $.hasMore;
+
+    method Hash(--> Hash) {
+        my %h = values => @!values.Array;
+        %h<total> = $_ with $!total;
+        %h<hasMore> = $_ with $!hasMore;
+        %h
+    }
+
+    method from-hash(%h --> CompletionResult) {
+        my @vals = |(%h<values> // []);
+        my %args;
+        %args<total> = %h<total> if %h<total>.defined;
+        %args<hasMore> = %h<hasMore> if %h<hasMore>.defined;
+        self.new(values => @vals, |%args)
+    }
+}
+
 #| Full server capabilities
 class ServerCapabilities is export {
     has Bool $.experimental;
@@ -439,6 +465,7 @@ class ServerCapabilities is export {
     has PromptsCapability $.prompts;
     has ResourcesCapability $.resources;
     has ToolsCapability $.tools;
+    has CompletionsCapability $.completions;
 
     method Hash(--> Hash) {
         my %h;
@@ -447,6 +474,7 @@ class ServerCapabilities is export {
         %h<prompts> = $!prompts.Hash if $!prompts;
         %h<resources> = $!resources.Hash if $!resources;
         %h<tools> = $!tools.Hash if $!tools;
+        %h<completions> = $!completions.Hash if $!completions;
         %h
     }
 
@@ -457,6 +485,7 @@ class ServerCapabilities is export {
             prompts => %h<prompts> ?? PromptsCapability.new(|%h<prompts>) !! PromptsCapability,
             resources => %h<resources> ?? ResourcesCapability.new(|%h<resources>) !! ResourcesCapability,
             tools => %h<tools> ?? ToolsCapability.new(|%h<tools>) !! ToolsCapability,
+            completions => %h<completions> ?? CompletionsCapability.new !! CompletionsCapability,
         )
     }
 }

--- a/t/01-types.rakutest
+++ b/t/01-types.rakutest
@@ -16,7 +16,7 @@ use lib 'lib';
 
 use MCP::Types;
 
-plan 27;
+plan 29;
 
 # Test Implementation
 subtest 'Implementation', {
@@ -300,6 +300,41 @@ subtest 'Root', {
     my $restored = Root.from-hash({ uri => 'file:///restored', name => 'Restored' });
     is $restored.uri, 'file:///restored', 'from-hash restores uri';
     is $restored.name, 'Restored', 'from-hash restores name';
+};
+
+# Test CompletionsCapability
+subtest 'CompletionsCapability', {
+    my $cap = CompletionsCapability.new;
+    my %h = $cap.Hash;
+    is %h.keys.elems, 0, 'empty hash';
+};
+
+# Test CompletionResult
+subtest 'CompletionResult', {
+    my $result = CompletionResult.new(
+        values => <alpha beta gamma>,
+        total => 10,
+        hasMore => True,
+    );
+    is $result.values.elems, 3, 'has 3 values';
+    is $result.total, 10, 'total is 10';
+    ok $result.hasMore, 'hasMore is true';
+
+    my %h = $result.Hash;
+    is %h<values>.elems, 3, 'Hash has values';
+    is %h<total>, 10, 'Hash has total';
+    ok %h<hasMore>, 'Hash hasMore';
+
+    # from-hash
+    my $restored = CompletionResult.from-hash(%h);
+    is $restored.values.elems, 3, 'from-hash restores values';
+    is $restored.total, 10, 'from-hash restores total';
+
+    # Without optional fields
+    my $minimal = CompletionResult.new(values => ['x']);
+    my %h2 = $minimal.Hash;
+    nok %h2<total>:exists, 'no total when not set';
+    nok %h2<hasMore>:exists, 'no hasMore when not set';
 };
 
 # Test ElicitationAction enum

--- a/t/05-server.rakutest
+++ b/t/05-server.rakutest
@@ -724,4 +724,88 @@ subtest 'Server elicitation', {
     is @notifications[0].params<elicitationId>, 'test-123', 'notification has elicitationId';
 };
 
+# Test completion/complete
+subtest 'Completion support', {
+    my $transport = TestTransport::TestTransport.new;
+    my $server = MCP::Server::Server.new(
+        info => MCP::Types::Implementation.new(name => 'test', version => '0.1'),
+        transport => $transport,
+    );
+
+    # Register a prompt completer that returns suggestions
+    $server.add-prompt-completer('code-review', -> $arg-name, $value, *%context {
+        my @all = <python javascript typescript ruby go rust>;
+        my @matched = @all.grep(*.starts-with($value));
+        { values => @matched }
+    });
+
+    # Register a resource completer
+    $server.add-resource-completer('file:///projects', -> $arg-name, $value, *%context {
+        <project-a project-b project-c>.grep(*.starts-with($value)).Array
+    });
+
+    # Test prompt completion
+    my $req1 = MCP::JSONRPC::Request.new(
+        id => 1,
+        method => 'completion/complete',
+        params => {
+            ref => { type => 'ref/prompt', name => 'code-review' },
+            argument => { name => 'language', value => 'py' },
+        },
+    );
+    $server.handle-message-public($req1);
+    my @sent = $transport.sent;
+    ok @sent.elems >= 1, 'got response';
+    my $resp1 = @sent[*-1];
+    ok $resp1 ~~ MCP::JSONRPC::Response, 'response is Response';
+    ok $resp1.result<completion>.defined, 'has completion';
+    is $resp1.result<completion><values>, ['python'], 'filtered to matching values';
+
+    # Test resource completion returning an Array
+    $transport.clear-sent;
+    my $req2 = MCP::JSONRPC::Request.new(
+        id => 2,
+        method => 'completion/complete',
+        params => {
+            ref => { type => 'ref/resource', uri => 'file:///projects' },
+            argument => { name => 'name', value => 'project-a' },
+        },
+    );
+    $server.handle-message-public($req2);
+    my $resp2 = $transport.sent[*-1];
+    is $resp2.result<completion><values>, ['project-a'], 'resource completion works';
+
+    # Test completion with no completer registered (empty result)
+    $transport.clear-sent;
+    my $req3 = MCP::JSONRPC::Request.new(
+        id => 3,
+        method => 'completion/complete',
+        params => {
+            ref => { type => 'ref/prompt', name => 'unknown-prompt' },
+            argument => { name => 'arg', value => 'x' },
+        },
+    );
+    $server.handle-message-public($req3);
+    my $resp3 = $transport.sent[*-1];
+    is $resp3.result<completion><values>, [], 'unregistered completer returns empty';
+
+    # Test invalid ref type
+    $transport.clear-sent;
+    my $req4 = MCP::JSONRPC::Request.new(
+        id => 4,
+        method => 'completion/complete',
+        params => {
+            ref => { type => 'ref/invalid' },
+            argument => { name => 'arg', value => 'x' },
+        },
+    );
+    $server.handle-message-public($req4);
+    my $resp4 = $transport.sent[*-1];
+    ok $resp4.error.defined, 'invalid ref type returns error';
+
+    # Test capabilities include completions
+    my $caps = $server.capabilities;
+    ok $caps.completions.defined, 'capabilities include completions';
+};
+
 done-testing;

--- a/t/06-client.rakutest
+++ b/t/06-client.rakutest
@@ -510,4 +510,61 @@ subtest 'Client elicitation support', {
     is @responses[0].error.code, MCP::JSONRPC::MethodNotFound.value, 'error is MethodNotFound';
 };
 
+# Test completion support
+subtest 'Completion support', {
+    my $transport = TestTransport::TestTransport.new;
+    my $client = MCP::Client::Client.new(
+        info => MCP::Types::Implementation.new(name => 'test-client', version => '0.1'),
+        transport => $transport,
+    );
+
+    # Simulate init response in background
+    start {
+        sleep 0.1;
+        respond-to-last($transport, {
+            protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
+            capabilities => { completions => {} },
+            serverInfo => { name => 'test-server', version => '0.1' },
+            instructions => 'test',
+        });
+    }
+    await $client.connect;
+
+    # Test complete-prompt
+    start {
+        sleep 0.1;
+        respond-to-last($transport, {
+            completion => { values => ['python', 'perl'], hasMore => False },
+        });
+    }
+    my $result = await $client.complete-prompt('code-review',
+        argument-name => 'language',
+        value => 'p',
+    );
+    ok $result ~~ MCP::Types::CompletionResult, 'result is CompletionResult';
+    is $result.values.elems, 2, 'has 2 values';
+    is $result.values[0], 'python', 'first value correct';
+
+    # Test complete-resource
+    start {
+        sleep 0.1;
+        respond-to-last($transport, {
+            completion => { values => ['file:///a'], total => 5, hasMore => True },
+        });
+    }
+    my $result2 = await $client.complete-resource('file:///projects',
+        argument-name => 'uri',
+        value => 'file:',
+    );
+    is $result2.values.elems, 1, 'resource completion has values';
+    is $result2.total, 5, 'has total';
+    ok $result2.hasMore, 'hasMore is true';
+
+    # Verify request was sent correctly
+    my @requests = $transport.sent.grep(MCP::JSONRPC::Request).grep(*.method eq 'completion/complete');
+    is @requests.elems, 2, 'sent 2 completion requests';
+    is @requests[0].params<ref><type>, 'ref/prompt', 'first request is prompt ref';
+    is @requests[1].params<ref><type>, 'ref/resource', 'second request is resource ref';
+};
+
 done-testing;


### PR DESCRIPTION
## Summary
Add autocomplete support for prompt arguments and resource URIs.

## Requirements

### Server Side
- Handle `completion/complete` requests
- Support completion for:
  - Prompt argument values (`ref.type = 'ref/prompt'`)
  - Resource URIs (`ref.type = 'ref/resource'`)
- Return `completion.values` array with suggestions
- Support `completion.hasMore` for partial results

### Types
- Add `CompletionRequest` with `ref` and `argument`
- Add `CompletionResult` with `values` and `total`/`hasMore`

## Example
```json
{
  "method": "completion/complete",
  "params": {
    "ref": { "type": "ref/prompt", "name": "git-commit" },
    "argument": { "name": "branch", "value": "feat" }
  }
}
```

## References
- [MCP Specification - Completion](https://modelcontextprotocol.io/specification/2025-11-25)