### PR TITLE
[CLEANUP] Add examples for advanced MCP features

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "perl": "6.d",
     "auth": "github:wkusnierczyk",
     "license": "MIT",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.10.0
+VERSION         := 0.11.0
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ See [Gap Analysis](GAP_ANALYSIS.md) for details on implemented and missing featu
   - [Tools](#tools)
   - [Resources](#resources)
   - [Prompts](#prompts)
+- [Examples](#examples)
 - [Development](#development)
   - [Makefile Targets](#makefile-targets)
   - [Environment Variables](#environment-variables)
@@ -259,6 +260,50 @@ say $call-result.content[0].text;  # "Hello, World!"
 # Read resources
 my @contents = await $client.read-resource('info://about');
 say @contents[0].text;
+```
+
+## Examples
+
+The `examples/` directory contains runnable, minimal reference implementations that demonstrate common MCP SDK patterns. Use them to quickly validate your environment, see how transports and handlers fit together, and copy a solid starting point for your own servers and clients.
+
+To list available examples:
+
+```
+# execute without naming any example
+make run-examples
+
+Available examples:
+  • advanced-client      # In-process loopback covering pagination, completions, roots, and elicitation
+  • advanced-server      # Pagination, resource subscriptions, and cancellation
+  • http-server          # Streamable HTTP server transport
+  • sampling-client      # Client-side sampling handler
+  • simple-server        # Stdio server with tools, resources, and prompts
+```
+
+Run any example with:
+
+```bash
+# execute naming an example
+make run-example EXAMPLE=advanced-server
+
+→ Running example: advanced-server...
+
+== Pagination ==
+Page 1 tools: tool-beta, tool-epsilon
+Page 1 nextCursor present: yes
+Page 2 tools: tool-alpha, tool-delta
+Page 2 nextCursor present: yes
+
+== Resource Subscriptions ==
+Subscribe result keys: 
+Update notifications sent: 1
+Last notification method: notifications/resources/updated
+
+== Cancellation ==
+Marked cancelled: yes
+Responses sent after cancellation: 0
+
+Done.
 ```
 
 ## Features

--- a/examples/advanced-client.raku
+++ b/examples/advanced-client.raku
@@ -1,0 +1,226 @@
+#!/usr/bin/env raku
+use v6.d;
+
+use MCP::Server;
+use MCP::Client;
+use MCP::Types;
+use MCP::Transport::Base;
+use MONKEY-TYPING;
+need MCP::JSONRPC;
+
+=begin pod
+=head1 NAME
+
+advanced-client - In-process client/server loopback for advanced features
+
+=head1 DESCRIPTION
+
+Creates a client and a server connected by an in-process loopback transport.
+This keeps the example fully runnable without external services while still
+demonstrating:
+
+- Pagination through list endpoints
+- Completions for prompts and resources
+- Roots (server requesting roots from the client)
+- Elicitation (server asking the client for input)
+
+=head1 USAGE
+
+    make run-example EXAMPLE=advanced-client
+
+=end pod
+
+class LoopbackTransport does MCP::Transport::Base::Transport {
+    has Supplier $!incoming = Supplier.new;
+    has Bool $!connected = False;
+    has LoopbackTransport $.peer is rw;
+    has @!sent;
+
+    method start(--> Supply) {
+        $!connected = True;
+        $!incoming.Supply;
+    }
+
+    method send(MCP::JSONRPC::Message $msg --> Promise) {
+        @!sent.push($msg);
+        $.peer!emit($msg) if $.peer.defined;
+        Promise.kept(True);
+    }
+
+    method close(--> Promise) {
+        $!connected = False;
+        $!incoming.done;
+        Promise.kept(True);
+    }
+
+    method is-connected(--> Bool) { $!connected }
+
+    method !emit(MCP::JSONRPC::Message $msg) {
+        $!incoming.emit($msg);
+    }
+}
+
+sub loopback-pair(--> List) {
+    my $a = LoopbackTransport.new;
+    my $b = LoopbackTransport.new;
+    $a.peer = $b;
+    $b.peer = $a;
+    ($a, $b)
+}
+
+augment class MCP::Server::Server {
+    method handle-message-public($msg) { self!handle-message($msg) }
+}
+
+sub show-pagination(Client $client) {
+    say "\n== Pagination ==";
+
+    my %tools-page1 = await $client.list-tools;
+    say "Tools page 1: " ~ %tools-page1<tools>.map(*.name).sort.join(', ');
+    if %tools-page1<nextCursor>:exists {
+        my %tools-page2 = await $client.list-tools(cursor => %tools-page1<nextCursor>);
+        say "Tools page 2: " ~ %tools-page2<tools>.map(*.name).sort.join(', ');
+    }
+
+    my %prompts-page1 = await $client.list-prompts;
+    say "Prompts page 1: " ~ %prompts-page1<prompts>.map(*.name).sort.join(', ');
+    if %prompts-page1<nextCursor>:exists {
+        my %prompts-page2 = await $client.list-prompts(cursor => %prompts-page1<nextCursor>);
+        say "Prompts page 2: " ~ %prompts-page2<prompts>.map(*.name).sort.join(', ');
+    }
+}
+
+sub show-completions(Client $client) {
+    say "\n== Completions ==";
+
+    my $prompt-result = await $client.complete-prompt(
+        'code-review',
+        argument-name => 'language',
+        value => 'ru',
+    );
+    say "Prompt completion values: " ~ $prompt-result.values.join(', ');
+
+    my $resource-result = await $client.complete-resource(
+        'file:///projects',
+        argument-name => 'path',
+        value => 'pro',
+    );
+    say "Resource completion values: " ~ $resource-result.values.join(', ');
+}
+
+sub show-roots-and-elicitation(Server $server) {
+    say "\n== Roots ==";
+    my @roots = await $server.list-roots;
+    say "Roots from client: " ~ @roots.map(*.uri).join(', ');
+
+    say "\n== Elicitation ==";
+    my $form-response = await $server.elicit(
+        message => 'Who is approving this request?',
+        schema => {
+            type => 'object',
+            properties => {
+                name => { type => 'string' },
+                approved => { type => 'boolean' },
+            },
+            required => ['name', 'approved'],
+        },
+    );
+    say "Form elicitation action: {$form-response.action}";
+    say "Form elicitation content keys: " ~ ($form-response.content // {}).keys.join(', ');
+
+    my $url-response = await $server.elicit-url(
+        message => 'Open the approval UI',
+        url => 'https://example.test/approve',
+        elicitation-id => 'approval-1',
+    );
+    say "URL elicitation action: {$url-response.action}";
+
+    $server.notify-elicitation-complete('approval-1');
+}
+
+my ($server-transport, $client-transport) = loopback-pair;
+
+my $server = Server.new(
+    info => Implementation.new(name => 'advanced-server', version => '0.1.0'),
+    transport => $server-transport,
+    page-size => 2,
+    instructions => 'Loopback server for advanced client features',
+);
+
+# Seed enough data for pagination
+for <alpha beta gamma delta epsilon> -> $name {
+    $server.add-tool(
+        name => "tool-$name",
+        description => "Demo tool $name",
+        handler => -> { "result-$name" },
+    );
+}
+
+for <code-review explain summarize> -> $name {
+    $server.add-prompt(
+        name => $name,
+        description => "Prompt $name",
+        generator => -> :%params { "prompt-$name for " ~ (%params<topic> // 'general') },
+    );
+}
+
+$server.add-resource(
+    uri => 'file:///projects',
+    name => 'Projects root',
+    description => 'Root folder for projects',
+    mimeType => 'text/plain',
+    reader => { 'project listing placeholder' },
+);
+
+# Register completion handlers
+$server.add-prompt-completer('code-review', -> $arg-name, $value, *%context {
+    my @langs = <raku ruby rust python perl>;
+    @langs.grep(*.starts-with($value.lc)).Array
+});
+
+$server.add-resource-completer('file:///projects', -> $arg-name, $value, *%context {
+    my @paths = <project-a project-b prototype docs>;
+    my @filtered = @paths.grep(*.starts-with($value.lc));
+    CompletionResult.new(values => @filtered, total => @paths.elems, hasMore => False)
+});
+
+# Start server loop
+$server.serve;
+
+my @roots = [
+    Root.new(uri => 'file:///project', name => 'Project'),
+    Root.new(uri => 'file:///tmp', name => 'Temp'),
+];
+
+my $capabilities = ClientCapabilities.new(
+    elicitation => ElicitationCapability.new(form => True, url => True),
+);
+
+my $client = Client.new(
+    info => Implementation.new(name => 'advanced-client', version => '0.1.0'),
+    transport => $client-transport,
+    capabilities => $capabilities,
+    roots => @roots,
+    elicitation-handler => -> %params {
+        ElicitationResponse.new(
+            action => ElicitAccept,
+            content => {
+                name => 'Example User',
+                approved => True,
+                mode => %params<mode>,
+            },
+        )
+    },
+);
+
+await $client.connect;
+
+show-pagination($client);
+show-completions($client);
+show-roots-and-elicitation($server);
+
+await $client.close;
+await $client-transport.close;
+await $server-transport.close;
+
+say "\nDone.";

--- a/examples/advanced-server.raku
+++ b/examples/advanced-server.raku
@@ -1,0 +1,172 @@
+#!/usr/bin/env raku
+use v6.d;
+
+use MCP::Server;
+use MCP::Types;
+use MCP::Transport::Base;
+use MONKEY-TYPING;
+need MCP::JSONRPC;
+
+=begin pod
+=head1 NAME
+
+advanced-server - Server-side pagination, subscriptions, and cancellation
+
+=head1 DESCRIPTION
+
+Runs entirely in-process using a tiny recording transport. It demonstrates
+three implemented features that are easy to miss when only looking at the
+basic examples:
+
+- Cursor-based pagination
+- Resource subscriptions and update notifications
+- Request cancellation that suppresses a response
+
+=head1 USAGE
+
+    make run-example EXAMPLE=advanced-server
+
+=end pod
+
+class RecordingTransport does MCP::Transport::Base::Transport {
+    has Supplier $!incoming = Supplier.new;
+    has Bool $!connected = False;
+    has @!sent;
+
+    method start(--> Supply) {
+        $!connected = True;
+        $!incoming.Supply;
+    }
+
+    method send(MCP::JSONRPC::Message $msg --> Promise) {
+        @!sent.push($msg);
+        Promise.kept(True);
+    }
+
+    method close(--> Promise) {
+        $!connected = False;
+        $!incoming.done;
+        Promise.kept(True);
+    }
+
+    method is-connected(--> Bool) { $!connected }
+
+    method sent(--> Array) { @!sent }
+    method clear-sent() { @!sent = () }
+}
+
+augment class MCP::Server::Server {
+    method handle-message-public($msg) { self!handle-message($msg) }
+}
+
+sub demo-pagination(Server $server) {
+    say "\n== Pagination ==";
+
+    my %page1 = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 'page-1',
+        method => 'tools/list',
+    ));
+    say "Page 1 tools: " ~ %page1<tools>.map(*<name>).sort.join(', ');
+    say "Page 1 nextCursor present: " ~ (%page1<nextCursor>.defined ?? 'yes' !! 'no');
+
+    my %page2 = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 'page-2',
+        method => 'tools/list',
+        params => { cursor => %page1<nextCursor> },
+    ));
+    say "Page 2 tools: " ~ %page2<tools>.map(*<name>).sort.join(', ');
+    say "Page 2 nextCursor present: " ~ (%page2<nextCursor>.defined ?? 'yes' !! 'no');
+}
+
+sub demo-subscriptions(Server $server, RecordingTransport $transport) {
+    say "\n== Resource Subscriptions ==";
+    $transport.clear-sent;
+
+    my %sub = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 'sub-1',
+        method => 'resources/subscribe',
+        params => { uri => 'info://clock' },
+    ));
+    say "Subscribe result keys: " ~ %sub.keys.join(', ');
+
+    $server.notify-resource-updated('info://clock');
+
+    my @notifications = $transport.sent.grep(MCP::JSONRPC::Notification);
+    say "Update notifications sent: {@notifications.elems}";
+    if @notifications {
+        say "Last notification method: " ~ @notifications[*-1].method;
+    }
+}
+
+sub demo-cancellation(Server $server, RecordingTransport $transport) {
+    say "\n== Cancellation ==";
+    $transport.clear-sent;
+
+    my $gate = Promise.new;
+    my $vow = $gate.vow;
+
+    $server.add-tool(
+        name => 'slow-tool',
+        description => 'Waits until released, useful for cancellation demos',
+        handler => -> {
+            await $gate;
+            'completed'
+        }
+    );
+
+    my $task = start {
+        $server.handle-message-public(MCP::JSONRPC::Request.new(
+            id => 'cancel-demo-1',
+            method => 'tools/call',
+            params => { name => 'slow-tool', arguments => {} },
+        ));
+    };
+
+    sleep 0.05;
+
+    $server.handle-message-public(MCP::JSONRPC::Notification.new(
+        method => 'notifications/cancelled',
+        params => { requestId => 'cancel-demo-1', reason => 'demo cancel' },
+    ));
+
+    say "Marked cancelled: " ~ ($server.is-cancelled('cancel-demo-1') ?? 'yes' !! 'no');
+
+    $vow.keep(True);
+    await $task;
+
+    my @responses = $transport.sent.grep(MCP::JSONRPC::Response);
+    say "Responses sent after cancellation: {@responses.elems}";
+}
+
+my $transport = RecordingTransport.new;
+my $server = Server.new(
+    info => Implementation.new(name => 'advanced-server', version => '0.1.0'),
+    transport => $transport,
+    page-size => 2,
+);
+
+# Seed tools for pagination
+for <alpha beta gamma delta epsilon> -> $name {
+    $server.add-tool(
+        name => "tool-$name",
+        description => "Demo tool $name",
+        handler => -> { "result-$name" },
+    );
+}
+
+# Resource used by the subscription demo
+$server.add-resource(
+    uri => 'info://clock',
+    name => 'Clock',
+    description => 'A ticking clock resource',
+    mimeType => 'text/plain',
+    reader => { DateTime.now.Str },
+);
+
+demo-pagination($server);
+demo-subscriptions($server, $transport);
+demo-cancellation($server, $transport);
+
+await $transport.close;
+
+say "\nDone.";


### PR DESCRIPTION
## Summary
The repository has solid basic examples, but it is missing examples for several implemented MCP features.

## Motivation
Current examples cover stdio server basics, HTTP transport, and sampling. Tests show additional capabilities that are not demonstrated in examples, which makes exploration and adoption harder.

## Proposed additions
Add one or more focused examples that demonstrate:
- Pagination
- Cancellation
- Resource subscriptions
- Completions
- Roots
- Elicitation (form and URL modes)

## Suggested scope (incremental)
1. Add a stdio server example that includes subscriptions, cancellation, and pagination.
2. Add a client example that exercises completions, roots, and elicitation.
3. Update README to point to the new examples and briefly describe what each one covers.

## Acceptance criteria
- New examples run without external services.
- Each example has a short pod-style header with usage.
- README links to each example and explains its purpose.
