### PR TITLE
Implement OAuth 2.1 authorization support (#22)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Install dependencies
         run: zef install --deps-only .
 
+      - name: Ensure JSON::Fast is installed
+        run: zef install JSON::Fast
+
       - name: Run tests
         run: |
           zef install App::Prove6 || true

--- a/GAP_ANALYSIS.md
+++ b/GAP_ANALYSIS.md
@@ -15,7 +15,7 @@ This document compares the current implementation of the Raku MCP SDK against th
 | **Server Features** | ⚠️ Partial | Tools/Resources/Prompts basic support |
 | **Client Features** | ⚠️ Partial | Sampling basic support |
 | **Utilities** | ⚠️ Partial | Logging, progress, cancellation implemented |
-| **Authorization** | ❌ Missing | OAuth 2.1 not implemented |
+| **Authorization** | ✅ Done | OAuth 2.1 with PKCE |
 | **New 2025-11-25 Features** | ⚠️ Partial | Elicitation done, Tasks/Extensions missing |
 
 ---
@@ -192,15 +192,17 @@ This document compares the current implementation of the Raku MCP SDK against th
 
 ### Authorization (2025-03-26+)
 
-#### ❌ Not Implemented
-The entire authorization framework is missing:
+#### ✅ Implemented
+OAuth 2.1 authorization framework:
 
-- OAuth 2.1 with PKCE
-- Dynamic client registration
-- Token refresh
-- Resource indicators (RFC 8707)
-- Authorization server metadata discovery
-- Protected resource metadata
+- ✅ OAuth 2.1 with PKCE (S256)
+- ✅ Token refresh
+- ✅ Resource indicators (RFC 8707)
+- ✅ Authorization server metadata discovery (RFC 8414 + OIDC fallback)
+- ✅ Protected resource metadata (RFC 9728)
+- ✅ Server-side token validation with WWW-Authenticate headers
+- ✅ Client-side automatic token management and 401 retry
+- ❌ Dynamic client registration
 
 ---
 
@@ -246,7 +248,7 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 | Sampling | ✅ Full + tools | ⚠️ Basic |
 | Roots | ✅ Full | ✅ Full |
 | Elicitation | ✅ Full + URL mode | ✅ Full |
-| OAuth 2.1 | ✅ Full | ❌ No |
+| OAuth 2.1 | ✅ Full | ✅ Core (no dynamic registration) |
 | Streamable HTTP | ✅ Full client + server | ✅ Full |
 | SSE Transport | ✅ Full | ❌ No |
 | Tasks | ✅ Experimental | ❌ No |
@@ -268,7 +270,7 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 6. ~~**Add tool output schemas**~~ ✅ **Done** - outputSchema and structuredContent support
 7. ~~**Implement elicitation**~~ ✅ **Done** - Form and URL mode with handler callbacks
 8. ~~**Add completion/autocomplete**~~ ✅ **Done** - Prompt and resource completion with handler registration
-9. **Implement OAuth 2.1** - Required for authenticated servers
+9. ~~**Implement OAuth 2.1**~~ ✅ **Done** - PKCE, token management, server validation
 
 ### Lower Priority (Advanced Features)
 10. **Tasks framework** - Long-running operations (experimental)
@@ -316,6 +318,6 @@ The Raku MCP SDK provides a solid foundation with core protocol support, but sig
 2. ~~Adding resource subscriptions for real-time updates~~ ✅ **Done**
 3. ~~Implementing pagination for scalability~~ ✅ **Done**
 4. ~~Adding roots support for filesystem servers~~ ✅ **Done**
-5. Implementing the authorization framework for secure connections
+5. ~~Implementing the authorization framework for secure connections~~ ✅ **Done**
 
 The SDK's architecture is well-designed and should accommodate these additions without major refactoring.

--- a/META6.json
+++ b/META6.json
@@ -19,12 +19,16 @@
         "MCP::Server::Tool": "lib/MCP/Server/Tool.rakumod",
         "MCP::Server::Resource": "lib/MCP/Server/Resource.rakumod",
         "MCP::Server::Prompt": "lib/MCP/Server/Prompt.rakumod",
-        "MCP::Client": "lib/MCP/Client.rakumod"
+        "MCP::Client": "lib/MCP/Client.rakumod",
+        "MCP::OAuth": "lib/MCP/OAuth.rakumod",
+        "MCP::OAuth::Client": "lib/MCP/OAuth/Client.rakumod",
+        "MCP::OAuth::Server": "lib/MCP/OAuth/Server.rakumod"
     },
     "depends": [
         "JSON::Fast",
         "Cro::HTTP",
-        "MIME::Base64"
+        "MIME::Base64",
+        "Digest::SHA256::Native"
     ],
     "test-depends": [
         "Test",

--- a/META6.json
+++ b/META6.json
@@ -27,8 +27,7 @@
     "depends": [
         "JSON::Fast",
         "Cro::HTTP",
-        "MIME::Base64",
-        "Digest::SHA256::Native"
+        "MIME::Base64"
     ],
     "test-depends": [
         "Test",

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.11.1",
+    "version": "0.12.0",
     "perl": "6.d",
     "auth": "github:wkusnierczyk",
     "license": "MIT",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.11.1
+VERSION         := 0.12.0
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Available examples:
   • advanced-client      # In-process loopback covering pagination, completions, roots, and elicitation
   • advanced-server      # Pagination, resource subscriptions, and cancellation
   • http-server          # Streamable HTTP server transport
+  • oauth-server         # HTTP server with OAuth 2.1 token validation
   • sampling-client      # Client-side sampling handler
   • simple-server        # Stdio server with tools, resources, and prompts
 ```
@@ -489,23 +490,26 @@ Regenerate the PNG with `make architecture-diagram`.
 ![Architecture diagram](architecture/architecture.png)
 
 ## Project structure
-
 ```
 MCP/
-├── MCP.rakumod              # Main module, re-exports
+├── MCP.rakumod                     # Main module, re-exports
 ├── MCP/
-│   ├── Types.rakumod        # Protocol types
-│   ├── JSONRPC.rakumod      # JSON-RPC 2.0
+│   ├── Types.rakumod               # Protocol types
+│   ├── JSONRPC.rakumod             # JSON-RPC 2.0
 │   ├── Transport/
-│   │   ├── Base.rakumod          # Transport role
-│   │   ├── Stdio.rakumod         # Stdio transport
-│   │   └── StreamableHTTP.rakumod # HTTP transport with SSE
-│   ├── Server.rakumod       # Server implementation
+│   │   ├── Base.rakumod            # Transport role
+│   │   ├── Stdio.rakumod           # Stdio transport
+│   │   └── StreamableHTTP.rakumod  # HTTP transport with SSE
+│   ├── OAuth.rakumod               # OAuth 2.1 types, PKCE, exceptions
+│   ├── OAuth/
+│   │   ├── Client.rakumod          # Client-side OAuth flow
+│   │   └── Server.rakumod          # Server-side token validation
+│   ├── Server.rakumod              # Server implementation
 │   ├── Server/
-│   │   ├── Tool.rakumod     # Tool helpers
-│   │   ├── Resource.rakumod # Resource helpers
-│   │   └── Prompt.rakumod   # Prompt helpers
-│   └── Client.rakumod       # Client implementation
+│   │   ├── Tool.rakumod            # Tool helpers
+│   │   ├── Resource.rakumod        # Resource helpers
+│   │   └── Prompt.rakumod          # Prompt helpers
+│   └── Client.rakumod              # Client implementation
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See [Gap Analysis](GAP_ANALYSIS.md) for details on implemented and missing featu
 | Completion | ✅ Done | Prompt and resource autocomplete with handler registration |
 | Tool output schemas | ✅ Done | `outputSchema` and `structuredContent` for structured results |
 | Tool metadata | ❌ Planned | icon metadata + tool name validation guidance |
-| OAuth 2.1 | ❌ Planned | OIDC discovery, incremental consent, client ID metadata |
+| OAuth 2.1 | ✅ Done | PKCE, token management, server validation, metadata discovery |
 
 ## Table of contents
 

--- a/architecture/architecture.mmd
+++ b/architecture/architecture.mmd
@@ -43,21 +43,35 @@ graph TD
         HTTP["MCP::Transport::StreamableHTTP"]
     end
 
+    subgraph Auth ["Authorization"]
+        direction TB
+        OAuth[MCP::OAuth<br/>Types, PKCE]
+        OAuthClient[MCP::OAuth::Client]
+        OAuthServer[MCP::OAuth::Server]
+    end
+
     Client --> JSONRPC
     Server --> JSONRPC
     JSONRPC --> Types
-    
+
     Client --> Transport
     Server --> Transport
     Transport -.-> Stdio
     Transport -.-> HTTP
-    
+
+    HTTP --> OAuthClient
+    HTTP --> OAuthServer
+    OAuthClient --> OAuth
+    OAuthServer --> OAuth
+
     Tool -.-> Types
     Resource -.-> Types
     Prompt -.-> Types
 
     %% Apply classes
+    classDef auth fill:#fff5ee,stroke:#d2691e,stroke-width:2px;
     class A,B user;
     class MCP,Client,Server,Tool,Resource,Prompt sdk;
     class JSONRPC,Types protocol;
     class Transport,Stdio,HTTP transport;
+    class OAuth,OAuthClient,OAuthServer auth;

--- a/examples/oauth-server.raku
+++ b/examples/oauth-server.raku
@@ -1,0 +1,75 @@
+#!/usr/bin/env raku
+use v6.d;
+
+use MCP;
+use MCP::Transport::StreamableHTTP;
+use MCP::OAuth::Server;
+
+=begin pod
+=head1 NAME
+
+oauth-server - Example MCP server with OAuth 2.1 token validation
+
+=head1 DESCRIPTION
+
+Starts an HTTP server that requires Bearer token authentication.
+The token validator is a simple callback; in production, this would
+verify JWTs or introspect tokens against an authorization server.
+
+Demonstrates:
+  - OAuthServerHandler setup with token validation
+  - Protected resource metadata endpoint
+  - WWW-Authenticate headers on 401/403
+
+=end pod
+
+# Simple in-memory token validator for demonstration
+my %valid-tokens = (
+    'demo-token-abc' => { sub => 'user1', scopes => ['read', 'write'] },
+    'read-only-token' => { sub => 'user2', scopes => ['read'] },
+);
+
+my $oauth = OAuthServerHandler.new(
+    resource-identifier => 'http://127.0.0.1:8080',
+    authorization-servers => ['https://auth.example.com'],
+    scopes-supported => ['read', 'write'],
+    token-validator => -> Str $token {
+        if %valid-tokens{$token}:exists {
+            my %info = %valid-tokens{$token};
+            { valid => True, sub => %info<sub>, scopes => %info<scopes> }
+        } else {
+            { valid => False, message => 'Unknown token' }
+        }
+    },
+);
+
+my $transport = StreamableHTTPServerTransport.new(
+    host => '127.0.0.1',
+    port => 8080,
+    path => '/mcp',
+    oauth-handler => $oauth,
+);
+
+my $server = Server.new(
+    info => Implementation.new(name => 'oauth-server', version => '0.1'),
+    transport => $transport,
+);
+
+$server.add-tool(
+    name => 'secret-data',
+    description => 'Return protected data (requires valid token)',
+    schema => { type => 'object', properties => {} },
+    handler => -> %args {
+        'This is protected data accessible only with a valid Bearer token.'
+    }
+);
+
+await $server.serve;
+say "OAuth-protected MCP server listening on http://127.0.0.1:8080/mcp";
+say "Protected resource metadata: http://127.0.0.1:8080/.well-known/oauth-protected-resource";
+say "";
+say "Test with valid token:";
+say "  curl -H 'Authorization: Bearer demo-token-abc' ...";
+say "Test without token (expect 401):";
+say "  curl http://127.0.0.1:8080/mcp ...";
+react { whenever Supply.interval(3600) { } }

--- a/lib/MCP/OAuth.rakumod
+++ b/lib/MCP/OAuth.rakumod
@@ -131,12 +131,123 @@ class PKCE is export {
                 return sha256-func($data);
             }
         }
-        # Fallback: use OpenSSL via shell
-        my $proc = run('openssl', 'dgst', '-sha256', '-binary', :in, :out);
-        $proc.in.write($data);
-        $proc.in.close;
-        my $result = $proc.out.slurp(:bin);
-        $result
+        # Pure Raku fallback to avoid platform-specific native toolchains.
+        self!sha256-pure($data)
+    }
+
+    method !sha256-pure(Blob $data --> Blob) {
+        my constant UInt $MASK = 0xFFFF_FFFF;
+
+        my constant @K = (
+            0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+            0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+            0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+            0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+            0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+            0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+            0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+            0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+            0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+            0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+            0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+            0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+            0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+            0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+            0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+            0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+        );
+
+        my UInt $h0 = 0x6a09e667;
+        my UInt $h1 = 0xbb67ae85;
+        my UInt $h2 = 0x3c6ef372;
+        my UInt $h3 = 0xa54ff53a;
+        my UInt $h4 = 0x510e527f;
+        my UInt $h5 = 0x9b05688c;
+        my UInt $h6 = 0x1f83d9ab;
+        my UInt $h7 = 0x5be0cd19;
+
+        my @bytes = $data.list;
+        my UInt $bit-len = @bytes.elems * 8;
+
+        @bytes.push(0x80);
+        while ((@bytes.elems % 64) != 56) {
+            @bytes.push(0x00);
+        }
+
+        for reverse ^8 -> $i {
+            @bytes.push(($bit-len +> ($i * 8)) +& 0xFF);
+        }
+
+        sub rotr(UInt $x, Int $n --> UInt) {
+            (($x +> $n) +| (($x +< (32 - $n)) +& $MASK)) +& $MASK
+        }
+        sub shr(UInt $x, Int $n --> UInt) { ($x +> $n) +& $MASK }
+        sub ch(UInt $x, UInt $y, UInt $z --> UInt) {
+            (($x +& $y) +^ ((+$x +& $MASK) +^ $MASK) +& $z) +& $MASK
+        }
+        sub maj(UInt $x, UInt $y, UInt $z --> UInt) {
+            (($x +& $y) +^ ($x +& $z) +^ ($y +& $z)) +& $MASK
+        }
+        sub sigma0(UInt $x --> UInt) { (rotr($x, 7) +^ rotr($x, 18) +^ shr($x, 3)) +& $MASK }
+        sub sigma1(UInt $x --> UInt) { (rotr($x, 17) +^ rotr($x, 19) +^ shr($x, 10)) +& $MASK }
+        sub capsigma0(UInt $x --> UInt) { (rotr($x, 2) +^ rotr($x, 13) +^ rotr($x, 22)) +& $MASK }
+        sub capsigma1(UInt $x --> UInt) { (rotr($x, 6) +^ rotr($x, 11) +^ rotr($x, 25)) +& $MASK }
+
+        for @bytes.rotor(64) -> @chunk {
+            my UInt @w = 0 xx 64;
+            for ^16 -> $i {
+                my $j = $i * 4;
+                @w[$i] = (
+                    ((@chunk[$j]     +& 0xFF) +< 24) +
+                    ((@chunk[$j + 1] +& 0xFF) +< 16) +
+                    ((@chunk[$j + 2] +& 0xFF) +< 8)  +
+                    ((@chunk[$j + 3] +& 0xFF))
+                ) +& $MASK;
+            }
+            for 16 ..^ 64 -> $i {
+                @w[$i] = (@w[$i - 16] + sigma0(@w[$i - 15]) + @w[$i - 7] + sigma1(@w[$i - 2])) +& $MASK;
+            }
+
+            my UInt $a = $h0;
+            my UInt $b = $h1;
+            my UInt $c = $h2;
+            my UInt $d = $h3;
+            my UInt $e = $h4;
+            my UInt $f = $h5;
+            my UInt $g = $h6;
+            my UInt $h = $h7;
+
+            for ^64 -> $i {
+                my UInt $t1 = ($h + capsigma1($e) + ch($e, $f, $g) + @K[$i] + @w[$i]) +& $MASK;
+                my UInt $t2 = (capsigma0($a) + maj($a, $b, $c)) +& $MASK;
+                $h = $g;
+                $g = $f;
+                $f = $e;
+                $e = ($d + $t1) +& $MASK;
+                $d = $c;
+                $c = $b;
+                $b = $a;
+                $a = ($t1 + $t2) +& $MASK;
+            }
+
+            $h0 = ($h0 + $a) +& $MASK;
+            $h1 = ($h1 + $b) +& $MASK;
+            $h2 = ($h2 + $c) +& $MASK;
+            $h3 = ($h3 + $d) +& $MASK;
+            $h4 = ($h4 + $e) +& $MASK;
+            $h5 = ($h5 + $f) +& $MASK;
+            $h6 = ($h6 + $g) +& $MASK;
+            $h7 = ($h7 + $h) +& $MASK;
+        }
+
+        my @out;
+        for $h0, $h1, $h2, $h3, $h4, $h5, $h6, $h7 -> $word {
+            @out.push(($word +> 24) +& 0xFF);
+            @out.push(($word +> 16) +& 0xFF);
+            @out.push(($word +> 8) +& 0xFF);
+            @out.push($word +& 0xFF);
+        }
+        Blob.new(@out)
     }
 
     method !base64url(Blob $data --> Str) {

--- a/lib/MCP/OAuth.rakumod
+++ b/lib/MCP/OAuth.rakumod
@@ -136,7 +136,7 @@ class PKCE is export {
     }
 
     method !sha256-pure(Blob $data --> Blob) {
-        my constant UInt $MASK = 0xFFFF_FFFF;
+        constant $MASK = 0xFFFF_FFFF;
 
         my constant @K = (
             0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,

--- a/lib/MCP/OAuth.rakumod
+++ b/lib/MCP/OAuth.rakumod
@@ -1,0 +1,149 @@
+use v6.d;
+
+#| OAuth 2.1 core types, PKCE utilities, and exceptions for MCP authorization
+unit module MCP::OAuth;
+
+use MIME::Base64;
+
+# === Exceptions ===
+
+class X::MCP::OAuth::Unauthorized is Exception is export {
+    has Str $.message = 'Unauthorized';
+    method message(--> Str) { $!message }
+}
+
+class X::MCP::OAuth::Forbidden is Exception is export {
+    has Str $.message = 'Forbidden';
+    has @.scopes;
+    method message(--> Str) { $!message }
+}
+
+class X::MCP::OAuth::Discovery is Exception is export {
+    has Str $.message = 'OAuth discovery failed';
+    method message(--> Str) { $!message }
+}
+
+# === Protected Resource Metadata (RFC 9728) ===
+
+class ProtectedResourceMetadata is export {
+    has Str $.resource is required;
+    has @.authorization-servers;
+    has @.scopes-supported;
+
+    method Hash(--> Hash) {
+        my %h = resource => $!resource;
+        %h<authorization_servers> = @!authorization-servers if @!authorization-servers;
+        %h<scopes_supported> = @!scopes-supported if @!scopes-supported;
+        %h
+    }
+
+    method from-hash(%h --> ProtectedResourceMetadata) {
+        self.new(
+            resource => %h<resource>,
+            authorization-servers => (%h<authorization_servers> // []).list,
+            scopes-supported => (%h<scopes_supported> // []).list,
+        )
+    }
+}
+
+# === Authorization Server Metadata (RFC 8414) ===
+
+class AuthServerMetadata is export {
+    has Str $.issuer is required;
+    has Str $.authorization-endpoint;
+    has Str $.token-endpoint;
+    has @.grant-types-supported;
+    has @.response-types-supported;
+    has @.scopes-supported;
+    has @.code-challenge-methods-supported;
+
+    method Hash(--> Hash) {
+        my %h = issuer => $!issuer;
+        %h<authorization_endpoint> = $!authorization-endpoint if $!authorization-endpoint;
+        %h<token_endpoint> = $!token-endpoint if $!token-endpoint;
+        %h<grant_types_supported> = @!grant-types-supported if @!grant-types-supported;
+        %h<response_types_supported> = @!response-types-supported if @!response-types-supported;
+        %h<scopes_supported> = @!scopes-supported if @!scopes-supported;
+        %h<code_challenge_methods_supported> = @!code-challenge-methods-supported if @!code-challenge-methods-supported;
+        %h
+    }
+
+    method from-hash(%h --> AuthServerMetadata) {
+        self.new(
+            issuer => %h<issuer>,
+            authorization-endpoint => %h<authorization_endpoint>,
+            token-endpoint => %h<token_endpoint>,
+            grant-types-supported => (%h<grant_types_supported> // []).list,
+            response-types-supported => (%h<response_types_supported> // []).list,
+            scopes-supported => (%h<scopes_supported> // []).list,
+            code-challenge-methods-supported => (%h<code_challenge_methods_supported> // []).list,
+        )
+    }
+}
+
+# === Token Response ===
+
+class TokenResponse is export {
+    has Str $.access-token is required;
+    has Str $.token-type = 'Bearer';
+    has Int $.expires-in;
+    has $.refresh-token;
+    has $.scope;
+    has Instant $.created-at = now;
+
+    method is-expired(--> Bool) {
+        return False unless $!expires-in.defined;
+        my $expiry = $!created-at + $!expires-in - 30; # 30s buffer
+        now > $expiry
+    }
+
+    method from-hash(%h --> TokenResponse) {
+        self.new(
+            access-token => %h<access_token>,
+            token-type => %h<token_type> // 'Bearer',
+            expires-in => %h<expires_in> ?? %h<expires_in>.Int !! Int,
+            refresh-token => %h<refresh_token>,
+            scope => %h<scope>,
+        )
+    }
+}
+
+# === PKCE (RFC 7636) ===
+
+class PKCE is export {
+    method generate-verifier(--> Str) {
+        my @chars = flat('A'..'Z', 'a'..'z', '0'..'9', '-', '.', '_', '~');
+        (^64).map({ @chars.pick }).join
+    }
+
+    method generate-challenge(Str $verifier --> Str) {
+        my $sha = self!sha256($verifier.encode('utf-8'));
+        self!base64url($sha)
+    }
+
+    method challenge-method(--> Str) { 'S256' }
+
+    method !sha256(Blob $data --> Blob) {
+        try {
+            my $mod = (require ::('Digest::SHA256::Native'));
+            my &sha256-func = ::('Digest::SHA256::Native').WHO<&sha256>;
+            if &sha256-func.defined {
+                return sha256-func($data);
+            }
+        }
+        # Fallback: use OpenSSL via shell
+        my $proc = run('openssl', 'dgst', '-sha256', '-binary', :in, :out);
+        $proc.in.write($data);
+        $proc.in.close;
+        my $result = $proc.out.slurp(:bin);
+        $result
+    }
+
+    method !base64url(Blob $data --> Str) {
+        my $encoded = MIME::Base64.encode($data, :oneline);
+        $encoded = $encoded.subst('+', '-', :g);
+        $encoded = $encoded.subst('/', '_', :g);
+        $encoded = $encoded.subst('=', '', :g);
+        $encoded
+    }
+}

--- a/lib/MCP/OAuth/Client.rakumod
+++ b/lib/MCP/OAuth/Client.rakumod
@@ -1,0 +1,192 @@
+use v6.d;
+
+#| OAuth 2.1 client-side handler for MCP transport
+unit module MCP::OAuth::Client;
+
+use MCP::OAuth;
+use JSON::Fast;
+
+class OAuthClientHandler is export {
+    has Str $.resource-url is required;
+    has Str $.client-id is required;
+    has Str $.client-secret;
+    has @.scopes;
+    has &.authorization-callback is required; # Str $url --> Str $code
+    has Str $.redirect-uri = 'http://localhost:8080/callback';
+
+    has TokenResponse $.token is rw;
+    has AuthServerMetadata $.auth-metadata is rw;
+    has ProtectedResourceMetadata $.resource-metadata is rw;
+    has Str $.pkce-verifier is rw;
+
+    method discover(--> Promise) {
+        start {
+            my $client = self!cro-client;
+
+            # Fetch protected resource metadata
+            my $resource-url = $!resource-url.subst(/ '/' $ /, '');
+            my $rm-url = "$resource-url/.well-known/oauth-protected-resource";
+            my $rm-resp = await $client.get($rm-url);
+            my $rm-body = await $rm-resp.body;
+            $!resource-metadata = ProtectedResourceMetadata.from-hash(
+                $rm-body ~~ Hash ?? $rm-body !! from-json($rm-body)
+            );
+
+            # Fetch auth server metadata
+            my $issuer = $!resource-metadata.authorization-servers[0]
+                // die X::MCP::OAuth::Discovery.new(message => 'No authorization server found');
+
+            my $issuer-base = $issuer.subst(/ '/' $ /, '');
+            my $as-body;
+            try {
+                my $as-resp = await $client.get("$issuer-base/.well-known/oauth-authorization-server");
+                $as-body = await $as-resp.body;
+                CATCH {
+                    default {
+                        # OIDC fallback
+                        my $oidc-resp = await $client.get("$issuer-base/.well-known/openid-configuration");
+                        $as-body = await $oidc-resp.body;
+                    }
+                }
+            }
+            $!auth-metadata = AuthServerMetadata.from-hash(
+                $as-body ~~ Hash ?? $as-body !! from-json($as-body)
+            );
+            True
+        }
+    }
+
+    method authorization-url(--> Str) {
+        die X::MCP::OAuth::Discovery.new(message => 'Must call discover() first')
+            unless $!auth-metadata.defined;
+
+        my $pkce = PKCE.new;
+        $!pkce-verifier = $pkce.generate-verifier;
+        my $challenge = $pkce.generate-challenge($!pkce-verifier);
+
+        my $state = (^32).map({ <a b c d e f 0 1 2 3 4 5 6 7 8 9>.pick }).join;
+
+        my $endpoint = $!auth-metadata.authorization-endpoint;
+        my @params;
+        @params.push("response_type=code");
+        @params.push("client_id={uri-encode($!client-id)}");
+        @params.push("redirect_uri={uri-encode($!redirect-uri)}");
+        @params.push("code_challenge={uri-encode($challenge)}");
+        @params.push("code_challenge_method=S256");
+        @params.push("resource={uri-encode($!resource-url)}");
+        @params.push("state={uri-encode($state)}");
+        @params.push("scope={uri-encode(@!scopes.join(' '))}") if @!scopes;
+
+        "$endpoint?{@params.join('&')}"
+    }
+
+    method authenticate(--> Promise) {
+        start {
+            await self.discover unless $!auth-metadata.defined;
+            my $url = self.authorization-url;
+            my $code = &!authorization-callback($url);
+            await self.exchange-code($code);
+            True
+        }
+    }
+
+    method exchange-code(Str $code --> Promise) {
+        start {
+            my $client = self!cro-client;
+            my %body =
+                grant_type => 'authorization_code',
+                code => $code,
+                redirect_uri => $!redirect-uri,
+                client_id => $!client-id,
+                code_verifier => $!pkce-verifier,
+                resource => $!resource-url;
+            %body<client_secret> = $!client-secret if $!client-secret.defined;
+
+            my $resp = await $client.post(
+                $!auth-metadata.token-endpoint,
+                content-type => 'application/x-www-form-urlencoded',
+                body => self!form-encode(%body),
+            );
+            my $body = await $resp.body;
+            my %token-data = $body ~~ Hash ?? $body !! from-json($body);
+            $!token = TokenResponse.from-hash(%token-data);
+            $!token
+        }
+    }
+
+    method refresh(--> Promise) {
+        start {
+            die X::MCP::OAuth::Unauthorized.new(message => 'No refresh token available')
+                unless $!token.defined && $!token.refresh-token.defined;
+
+            my $client = self!cro-client;
+            my %body =
+                grant_type => 'refresh_token',
+                refresh_token => $!token.refresh-token,
+                client_id => $!client-id,
+                resource => $!resource-url;
+            %body<client_secret> = $!client-secret if $!client-secret.defined;
+
+            my $resp = await $client.post(
+                $!auth-metadata.token-endpoint,
+                content-type => 'application/x-www-form-urlencoded',
+                body => self!form-encode(%body),
+            );
+            my $body = await $resp.body;
+            my %token-data = $body ~~ Hash ?? $body !! from-json($body);
+            $!token = TokenResponse.from-hash(%token-data);
+            $!token
+        }
+    }
+
+    method get-token(--> Promise) {
+        start {
+            if $!token.defined && !$!token.is-expired {
+                $!token
+            } elsif $!token.defined && $!token.refresh-token.defined {
+                await self.refresh
+            } else {
+                await self.authenticate;
+                $!token
+            }
+        }
+    }
+
+    method authorization-header(--> Promise) {
+        start {
+            my $token = await self.get-token;
+            "Bearer {$token.access-token}"
+        }
+    }
+
+    method handle-unauthorized(--> Promise) {
+        start {
+            $!token = Nil;
+            $!pkce-verifier = Nil;
+            await self.authenticate;
+            True
+        }
+    }
+
+    method !form-encode(%data --> Str) {
+        %data.kv.map(-> $k, $v { "{uri-encode($k)}={uri-encode($v)}" }).join('&')
+    }
+
+    method !cro-client() {
+        try {
+            require ::('Cro::HTTP::Client');
+            return ::('Cro::HTTP::Client').new;
+        }
+        CATCH {
+            default {
+                die X::MCP::OAuth::Discovery.new(
+                    message => 'Cro::HTTP is required for OAuth client'
+                );
+            }
+        }
+    }
+
+    sub uri-encode(Str $s --> Str) {
+        $s.subst(/<-[A..Za..z0..9\-._~]>/, { .Str.encode('utf-8').list.map({ '%' ~ .fmt('%02X') }).join }, :g)
+    }
+}

--- a/lib/MCP/OAuth/Server.rakumod
+++ b/lib/MCP/OAuth/Server.rakumod
@@ -1,0 +1,58 @@
+use v6.d;
+
+#| OAuth 2.1 server-side handler for MCP transport
+unit module MCP::OAuth::Server;
+
+use MCP::OAuth;
+
+class OAuthServerHandler is export {
+    has Str $.resource-identifier is required;
+    has @.authorization-servers;
+    has @.scopes-supported;
+    has &.token-validator is required; # Str $token --> Hash with 'valid' key
+
+    method resource-metadata(--> Hash) {
+        ProtectedResourceMetadata.new(
+            resource => $!resource-identifier,
+            authorization-servers => @!authorization-servers,
+            scopes-supported => @!scopes-supported,
+        ).Hash
+    }
+
+    method validate-request($req --> Hash) {
+        my $auth = $req.header('Authorization') // '';
+        unless $auth.starts-with('Bearer ') {
+            die X::MCP::OAuth::Unauthorized.new(
+                message => 'Missing or invalid Authorization header',
+            );
+        }
+        my $token = $auth.substr(7);
+        my %result = &!token-validator($token);
+        unless %result<valid> {
+            if %result<scopes>:exists {
+                die X::MCP::OAuth::Forbidden.new(
+                    message => %result<message> // 'Insufficient scope',
+                    scopes => %result<scopes>.list,
+                );
+            }
+            die X::MCP::OAuth::Unauthorized.new(
+                message => %result<message> // 'Invalid token',
+            );
+        }
+        %result
+    }
+
+    method www-authenticate-header(--> Str) {
+        my $value = 'Bearer';
+        $value ~= " resource_metadata=\"{$!resource-identifier}/.well-known/oauth-protected-resource\"";
+        $value
+    }
+
+    method www-authenticate-scope-header(@scopes --> Str) {
+        my $value = 'Bearer';
+        $value ~= " resource_metadata=\"{$!resource-identifier}/.well-known/oauth-protected-resource\"";
+        $value ~= ", error=\"insufficient_scope\"";
+        $value ~= ", scope=\"{@scopes.join(' ')}\"" if @scopes;
+        $value
+    }
+}

--- a/t/10-oauth.rakutest
+++ b/t/10-oauth.rakutest
@@ -1,0 +1,160 @@
+use v6.d;
+use Test;
+use lib 'lib';
+
+use MCP::OAuth;
+use MCP::OAuth::Server;
+
+plan 7;
+
+# === 1. PKCE ===
+subtest 'PKCE', {
+    plan 4;
+    my $pkce = PKCE.new;
+
+    my $verifier = $pkce.generate-verifier;
+    is $verifier.chars, 64, 'verifier is 64 characters';
+    ok $verifier ~~ /^<[A..Za..z0..9\-._~]>+$/, 'verifier uses valid characters';
+
+    my $challenge = $pkce.generate-challenge($verifier);
+    ok $challenge.chars > 0, 'challenge is non-empty';
+    nok $challenge ~~ /<[+=\/]>/, 'challenge is base64url (no +, =, /)';
+};
+
+# === 2. ProtectedResourceMetadata ===
+subtest 'ProtectedResourceMetadata', {
+    plan 4;
+    my $meta = ProtectedResourceMetadata.new(
+        resource => 'https://api.example.com',
+        authorization-servers => ['https://auth.example.com'],
+        scopes-supported => ['read', 'write'],
+    );
+    is $meta.resource, 'https://api.example.com', 'resource set';
+    my %h = $meta.Hash;
+    is %h<resource>, 'https://api.example.com', 'Hash roundtrip resource';
+    is %h<authorization_servers>[0], 'https://auth.example.com', 'Hash roundtrip auth servers';
+
+    my $from = ProtectedResourceMetadata.from-hash(%h);
+    is $from.resource, 'https://api.example.com', 'from-hash roundtrip';
+};
+
+# === 3. AuthServerMetadata ===
+subtest 'AuthServerMetadata', {
+    plan 4;
+    my $meta = AuthServerMetadata.new(
+        issuer => 'https://auth.example.com',
+        authorization-endpoint => 'https://auth.example.com/authorize',
+        token-endpoint => 'https://auth.example.com/token',
+        grant-types-supported => ['authorization_code'],
+        code-challenge-methods-supported => ['S256'],
+    );
+    is $meta.issuer, 'https://auth.example.com', 'issuer set';
+    my %h = $meta.Hash;
+    is %h<token_endpoint>, 'https://auth.example.com/token', 'Hash roundtrip token endpoint';
+
+    my $from = AuthServerMetadata.from-hash(%h);
+    is $from.issuer, 'https://auth.example.com', 'from-hash roundtrip issuer';
+    is $from.token-endpoint, 'https://auth.example.com/token', 'from-hash roundtrip token endpoint';
+};
+
+# === 4. TokenResponse ===
+subtest 'TokenResponse', {
+    plan 4;
+    my $token = TokenResponse.new(
+        access-token => 'abc123',
+        token-type => 'Bearer',
+        expires-in => 3600,
+        refresh-token => 'refresh456',
+        scope => 'read write',
+    );
+    is $token.access-token, 'abc123', 'access token set';
+    nok $token.is-expired, 'fresh token is not expired';
+
+    # Simulate expired token
+    my $expired = TokenResponse.new(
+        access-token => 'old',
+        expires-in => 1,
+        created-at => now - 100,
+    );
+    ok $expired.is-expired, 'old token is expired';
+
+    my $from = TokenResponse.from-hash({
+        access_token => 'xyz',
+        token_type => 'Bearer',
+        expires_in => 7200,
+    });
+    is $from.access-token, 'xyz', 'from-hash roundtrip';
+};
+
+# === 5. OAuthServerHandler ===
+subtest 'OAuthServerHandler', {
+    plan 5;
+    my $handler = OAuthServerHandler.new(
+        resource-identifier => 'https://api.example.com',
+        authorization-servers => ['https://auth.example.com'],
+        scopes-supported => ['read', 'write'],
+        token-validator => -> Str $token {
+            if $token eq 'valid-token' {
+                { valid => True, sub => 'user1' }
+            } else {
+                { valid => False, message => 'Invalid token' }
+            }
+        },
+    );
+
+    my %meta = $handler.resource-metadata;
+    is %meta<resource>, 'https://api.example.com', 'resource-metadata returns correct resource';
+    ok %meta<authorization_servers>:exists, 'resource-metadata has auth servers';
+
+    # Mock request with valid token
+    my $valid-req = class { method header($n) { 'Bearer valid-token' } }.new;
+    my %result = $handler.validate-request($valid-req);
+    ok %result<valid>, 'valid token passes validation';
+
+    # Mock request with invalid token
+    my $invalid-req = class { method header($n) { 'Bearer bad-token' } }.new;
+    dies-ok { $handler.validate-request($invalid-req) }, 'invalid token throws';
+
+    # WWW-Authenticate header format
+    my $www = $handler.www-authenticate-header;
+    ok $www.contains('Bearer'), 'www-authenticate starts with Bearer';
+};
+
+# === 6. OAuthClientHandler authorization-url ===
+subtest 'OAuthClientHandler authorization-url', {
+    plan 3;
+    use MCP::OAuth::Client;
+
+    my $client-handler = OAuthClientHandler.new(
+        resource-url => 'https://api.example.com',
+        client-id => 'test-client',
+        scopes => ['read'],
+        authorization-callback => -> Str $url { 'auth-code-123' },
+    );
+
+    # Manually set auth metadata to avoid HTTP calls
+    $client-handler.auth-metadata = AuthServerMetadata.new(
+        issuer => 'https://auth.example.com',
+        authorization-endpoint => 'https://auth.example.com/authorize',
+        token-endpoint => 'https://auth.example.com/token',
+    );
+
+    my $url = $client-handler.authorization-url;
+    ok $url.contains('code_challenge='), 'URL contains code_challenge';
+    ok $url.contains('client_id='), 'URL contains client_id';
+    ok $url.contains('resource='), 'URL contains resource';
+};
+
+# === 7. Transport backwards compatibility ===
+subtest 'Transport backwards compatibility', {
+    plan 1;
+    use MCP::Transport::StreamableHTTP;
+
+    # Server transport without oauth-handler should work fine
+    my $transport = StreamableHTTPServerTransport.new(
+        path => '/mcp',
+    );
+    nok $transport.oauth-handler.defined, 'oauth-handler is optional (not defined by default)';
+};
+
+done-testing;


### PR DESCRIPTION
Add modular OAuth 2.1 layer for HTTP transport with PKCE (S256), token management, and server-side validation. 

Three new modules: 
* MCP::OAuth (core types, PKCE, exceptions).
* MCP::OAuth::Server (token validation, resource metadata, WWW-Authenticate headers).
* MCP::OAuth::Client (discovery via RFC 8414/OIDC fallback, authorization flow, code exchange, token refresh, 401 retry). 

StreamableHTTP transport gains optional OAuth-handler attributes on both client and server sides.