### PR TITLE
Implement Tasks framework for long-running operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             raku-${{ runner.os }}-
 
       - name: Install dependencies
-        run: zef install --deps-only .
+        run: zef install --deps-only . --/test
 
       - name: Validate META6.json
         run: make lint-meta
@@ -94,7 +94,7 @@ jobs:
             raku-${{ runner.os }}-
 
       - name: Install dependencies
-        run: zef install --deps-only .
+        run: zef install --deps-only . --/test
 
       - name: Ensure JSON::Fast is installed
         run: zef install JSON::Fast
@@ -136,7 +136,7 @@ jobs:
             raku-${{ runner.os }}-
 
       - name: Install dependencies
-        run: zef install --deps-only .
+        run: zef install --deps-only . --/test
 
       - name: Install RaCoCo
         run: zef install App::RaCoCo
@@ -215,7 +215,7 @@ jobs:
           raku-version: ${{ env.RAKU_VERSION }}
 
       - name: Install dependencies
-        run: zef install --deps-only .
+        run: zef install --deps-only . --/test
 
       - name: Build module
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
             raku-${{ runner.os }}-
 
       - name: Install dependencies
-        run: zef install --deps-only .
+        run: zef install --deps-only . --/test
 
       - name: Run tests
         run: |
@@ -149,7 +149,7 @@ jobs:
             raku-${{ runner.os }}-
 
       - name: Install dependencies
-        run: zef install --deps-only .
+        run: zef install --deps-only . --/test
 
       - name: Validate META6.json
         run: |

--- a/GAP_ANALYSIS.md
+++ b/GAP_ANALYSIS.md
@@ -16,7 +16,7 @@ This document compares the current implementation of the Raku MCP SDK against th
 | **Client Features** | ⚠️ Partial | Sampling basic support |
 | **Utilities** | ⚠️ Partial | Logging, progress, cancellation implemented |
 | **Authorization** | ❌ Missing | OAuth 2.1 not implemented |
-| **New 2025-11-25 Features** | ⚠️ Partial | Elicitation done, Tasks/Extensions missing |
+| **New 2025-11-25 Features** | ⚠️ Partial | Elicitation done, Tasks done (experimental), Extensions missing |
 
 ---
 
@@ -206,13 +206,16 @@ The entire authorization framework is missing:
 
 ### New Features in 2025-11-25
 
-#### ❌ Tasks (Experimental)
+#### ✅ Tasks (Experimental)
 Long-running operation support:
-- Task creation with `_meta.task` hint
+- Task creation with `task` hint in `tools/call`
 - Task states: `working`, `input_required`, `completed`, `failed`, `cancelled`
 - `tasks/get` for status polling
 - `tasks/cancel` for cancellation
-- Task result retrieval
+- `tasks/result` for blocking result retrieval
+- `tasks/list` for listing all tasks
+- `notifications/tasks/status` on state changes
+- Tool-level `execution.taskSupport` via builder
 
 #### ❌ Extensions Framework
 - Extension capability negotiation
@@ -249,7 +252,7 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 | OAuth 2.1 | ✅ Full | ❌ No |
 | Streamable HTTP | ✅ Full client + server | ✅ Full |
 | SSE Transport | ✅ Full | ❌ No |
-| Tasks | ✅ Experimental | ❌ No |
+| Tasks | ✅ Experimental | ✅ Done (experimental) |
 | Completion | ✅ Full | ❌ No |
 | Pagination | ✅ Full | ✅ Full |
 
@@ -282,7 +285,6 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 Current implementation targets: **2025-11-25** ✅
 
 Key features still needed for full 2025-11-25 compliance:
-- Add Tasks support (experimental)
 - Add Extensions framework
 - Update capability negotiation for new features
 

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "perl": "6.d",
     "auth": "github:wkusnierczyk",
     "license": "MIT",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.12.0
+VERSION         := 0.13.0
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See [Gap Analysis](GAP_ANALYSIS.md) for details on implemented and missing featu
 | Sampling | ⚠️ Partial | Basic support, missing tools/toolChoice/includeContext/stopReason |
 | HTTP Transport | ✅ Done | Full client/server with session management, SSE, resumption |
 | Elicitation | ✅ Done | Form and URL modes with handler callbacks |
-| Tasks (experimental) | ❌ Planned | |
+| Tasks (experimental) | ✅ Done | Async tool execution, status polling, cancellation |
 | Extensions framework | ❌ Planned | |
 | Completion | ✅ Done | Prompt and resource autocomplete with handler registration |
 | Tool output schemas | ✅ Done | `outputSchema` and `structuredContent` for structured results |

--- a/lib/MCP.rakumod
+++ b/lib/MCP.rakumod
@@ -53,6 +53,9 @@ constant ModelHint is export = MCP::Types::ModelHint;
 constant ModelPreferences is export = MCP::Types::ModelPreferences;
 constant ToolChoice is export = MCP::Types::ToolChoice;
 constant CreateMessageResult is export = MCP::Types::CreateMessageResult;
+constant Task is export = MCP::Types::Task;
+constant TaskStatus is export = MCP::Types::TaskStatus;
+constant CreateTaskResult is export = MCP::Types::CreateTaskResult;
 
 #| Re-exported log level constants
 constant Debug is export = MCP::Types::Debug;

--- a/lib/MCP/Server/Tool.rakumod
+++ b/lib/MCP/Server/Tool.rakumod
@@ -23,6 +23,7 @@ class RegisteredTool is export {
     has Hash $.inputSchema;
     has Hash $.outputSchema;
     has MCP::Types::ToolAnnotations $.annotations;
+    has MCP::Types::TaskExecution $.execution;
     has &.handler is required;
 
     #| Get the Tool definition for listing
@@ -33,6 +34,7 @@ class RegisteredTool is export {
             inputSchema => $!inputSchema,
             outputSchema => $!outputSchema,
             annotations => $!annotations,
+            execution => $!execution,
         )
     }
 
@@ -116,6 +118,7 @@ class ToolBuilder is export {
     has Hash $!inputSchema = { type => 'object', properties => {}, required => [] };
     has Hash $!outputSchema;
     has MCP::Types::ToolAnnotations $!annotations;
+    has MCP::Types::TaskExecution $!execution;
     has &!handler;
 
     method name(Str $name --> ToolBuilder) {
@@ -216,6 +219,18 @@ class ToolBuilder is export {
         self
     }
 
+    #| Set task support level (forbidden, optional, required)
+    method task-support(Str $level --> ToolBuilder) {
+        my $ts = do given $level {
+            when 'forbidden' { MCP::Types::TaskForbidden }
+            when 'optional'  { MCP::Types::TaskOptional }
+            when 'required'  { MCP::Types::TaskRequired }
+            default          { MCP::Types::TaskOptional }
+        };
+        $!execution = MCP::Types::TaskExecution.new(taskSupport => $ts);
+        self
+    }
+
     method handler(&handler --> ToolBuilder) {
         &!handler = &handler;
         self
@@ -231,6 +246,7 @@ class ToolBuilder is export {
             inputSchema => $!inputSchema,
             outputSchema => $!outputSchema,
             annotations => $!annotations,
+            execution => $!execution,
             handler => &!handler,
         )
     }

--- a/t/11-tasks.rakutest
+++ b/t/11-tasks.rakutest
@@ -1,0 +1,303 @@
+use v6.d;
+use Test;
+use lib 'lib';
+use lib 't/lib';
+
+use MCP::Server;
+use MCP::Types;
+need MCP::JSONRPC;
+use MCP::Server::Tool;
+need TestTransport;
+use JSON::Fast;
+
+=begin pod
+=head1 NAME
+
+11-tasks.rakutest - Tests for MCP Tasks framework
+
+=head1 DESCRIPTION
+
+Covers Task types, async tool execution, task status polling,
+cancellation, listing, and capabilities.
+
+=end pod
+
+use MONKEY-TYPING;
+augment class MCP::Server::Server {
+    method handle-message-public($msg) { self!handle-message($msg) }
+}
+
+# --- Type tests ---
+
+subtest 'Task types', {
+    # TaskStatus enum
+    is MCP::Types::TaskWorking.value, 'working', 'TaskWorking value';
+    is MCP::Types::TaskCompleted.value, 'completed', 'TaskCompleted value';
+    is MCP::Types::TaskFailed.value, 'failed', 'TaskFailed value';
+    is MCP::Types::TaskCancelled.value, 'cancelled', 'TaskCancelled value';
+    is MCP::Types::TaskInputRequired.value, 'input_required', 'TaskInputRequired value';
+
+    # Task construction and Hash roundtrip
+    my $task = MCP::Types::Task.new(
+        taskId => 'task-abc',
+        status => MCP::Types::TaskWorking,
+        createdAt => '2025-01-01T00:00:00Z',
+        lastUpdatedAt => '2025-01-01T00:00:00Z',
+        ttl => 5000,
+        pollInterval => 1000,
+    );
+    is $task.taskId, 'task-abc', 'Task taskId';
+    is $task.status, MCP::Types::TaskWorking, 'Task status';
+    nok $task.is-terminal, 'working is not terminal';
+
+    my %h = $task.Hash;
+    is %h<taskId>, 'task-abc', 'Hash taskId';
+    is %h<status>, 'working', 'Hash status string';
+    is %h<ttl>, 5000, 'Hash ttl';
+
+    # from-hash roundtrip
+    my $task2 = MCP::Types::Task.from-hash(%h);
+    is $task2.taskId, 'task-abc', 'from-hash taskId';
+    is $task2.status, MCP::Types::TaskWorking, 'from-hash status';
+
+    # is-terminal for each status
+    ok MCP::Types::Task.new(taskId => 'x', status => MCP::Types::TaskCompleted).is-terminal, 'completed is terminal';
+    ok MCP::Types::Task.new(taskId => 'x', status => MCP::Types::TaskFailed).is-terminal, 'failed is terminal';
+    ok MCP::Types::Task.new(taskId => 'x', status => MCP::Types::TaskCancelled).is-terminal, 'cancelled is terminal';
+    nok MCP::Types::Task.new(taskId => 'x', status => MCP::Types::TaskInputRequired).is-terminal, 'input_required is not terminal';
+};
+
+subtest 'CreateTaskResult', {
+    my $task = MCP::Types::Task.new(taskId => 'task-1', status => MCP::Types::TaskWorking);
+    my $ctr = MCP::Types::CreateTaskResult.new(task => $task);
+    my %h = $ctr.Hash;
+    ok %h<task>:exists, 'CreateTaskResult Hash has task';
+    is %h<task><taskId>, 'task-1', 'Nested task data';
+};
+
+subtest 'TaskExecution', {
+    my $exec = MCP::Types::TaskExecution.new(taskSupport => MCP::Types::TaskRequired);
+    is $exec.Hash<taskSupport>, 'required', 'TaskExecution Hash';
+
+    my $exec2 = MCP::Types::TaskExecution.from-hash({ taskSupport => 'optional' });
+    is $exec2.taskSupport, MCP::Types::TaskOptional, 'TaskExecution from-hash';
+};
+
+subtest 'Tool with execution', {
+    my $tool = MCP::Types::Tool.new(
+        name => 'slow',
+        execution => MCP::Types::TaskExecution.new(taskSupport => MCP::Types::TaskRequired),
+    );
+    my %h = $tool.Hash;
+    is %h<execution><taskSupport>, 'required', 'Tool Hash includes execution';
+
+    my $tool2 = MCP::Types::Tool.from-hash(%h);
+    ok $tool2.execution.defined, 'Tool from-hash restores execution';
+    is $tool2.execution.taskSupport, MCP::Types::TaskRequired, 'Tool from-hash execution value';
+};
+
+# --- Server integration tests ---
+
+sub make-server() {
+    my $transport = TestTransport::TestTransport.new;
+    my $server = Server.new(
+        info => MCP::Types::Implementation.new(name => 'srv', version => '0.1'),
+        transport => $transport,
+    );
+
+    # Add a slow tool (simulates async work)
+    $server.add-tool(
+        name => 'slow-add',
+        description => 'Slow addition',
+        schema => { type => 'object', properties => { a => { type => 'number' }, b => { type => 'number' } } },
+        handler => -> :%params {
+            sleep 0.1;
+            MCP::Types::CallToolResult.new(
+                content => [MCP::Types::TextContent.new(text => (~(%params<a> + %params<b>)))],
+            )
+        }
+    );
+
+    ($server, $transport)
+}
+
+subtest 'Task creation via tools/call with task hint', {
+    my ($server, $transport) = make-server();
+
+    my $result = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 1,
+        method => 'tools/call',
+        params => { name => 'slow-add', arguments => { a => 2, b => 3 }, task => { ttl => 5000 } }
+    ));
+
+    ok $result<task>:exists, 'Response has task field';
+    is $result<task><status>, 'working', 'Task starts as working';
+    ok $result<task><taskId>.starts-with('task-'), 'Task ID has prefix';
+    ok $result<task><ttl>.defined, 'Task has ttl';
+};
+
+subtest 'tasks/get returns task status', {
+    my ($server, $transport) = make-server();
+
+    my $create = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 1,
+        method => 'tools/call',
+        params => { name => 'slow-add', arguments => { a => 1, b => 2 }, task => { ttl => 5000 } }
+    ));
+    my $task-id = $create<task><taskId>;
+
+    my $status = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 2,
+        method => 'tasks/get',
+        params => { taskId => $task-id }
+    ));
+
+    ok $status<taskId>:exists, 'tasks/get returns taskId';
+    is $status<taskId>, $task-id, 'Correct task ID';
+    ok $status<status> eq 'working' || $status<status> eq 'completed', 'Status is working or completed';
+};
+
+subtest 'tasks/result blocks until completion', {
+    my ($server, $transport) = make-server();
+
+    my $create = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 1,
+        method => 'tools/call',
+        params => { name => 'slow-add', arguments => { a => 10, b => 20 }, task => { ttl => 5000 } }
+    ));
+    my $task-id = $create<task><taskId>;
+
+    my $result = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 2,
+        method => 'tasks/result',
+        params => { taskId => $task-id }
+    ));
+
+    is $result<task><status>, 'completed', 'Task completed after result fetch';
+    ok $result<result>:exists, 'Result contains result data';
+    is $result<result><content>[0]<text>, '30', 'Correct tool result';
+};
+
+subtest 'tasks/cancel cancels a working task', {
+    my ($server, $transport) = make-server();
+
+    # Add a very slow tool
+    $server.add-tool(
+        name => 'very-slow',
+        description => 'Very slow',
+        handler => -> { sleep 10; 'done' }
+    );
+
+    my $create = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 1,
+        method => 'tools/call',
+        params => { name => 'very-slow', arguments => {}, task => { ttl => 30000 } }
+    ));
+    my $task-id = $create<task><taskId>;
+
+    my $cancel = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 2,
+        method => 'tasks/cancel',
+        params => { taskId => $task-id }
+    ));
+
+    is $cancel<status>, 'cancelled', 'Task cancelled';
+
+    # Verify notification was sent
+    my @notifs = $transport.sent.grep({ $_ ~~ MCP::JSONRPC::Notification && .method eq 'notifications/tasks/status' });
+    ok @notifs.elems >= 1, 'Status notification sent on cancel';
+};
+
+subtest 'tasks/list lists tasks', {
+    my ($server, $transport) = make-server();
+
+    # Create two tasks
+    for 1..2 -> $i {
+        $server.dispatch-request(MCP::JSONRPC::Request.new(
+            id => $i,
+            method => 'tools/call',
+            params => { name => 'slow-add', arguments => { a => $i, b => $i }, task => { ttl => 5000 } }
+        ));
+    }
+
+    my $list = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 3,
+        method => 'tasks/list',
+        params => {}
+    ));
+
+    ok $list<tasks>:exists, 'tasks/list returns tasks';
+    is $list<tasks>.elems, 2, 'Two tasks listed';
+};
+
+subtest 'Task status notification on completion', {
+    my ($server, $transport) = make-server();
+
+    my $create = $server.dispatch-request(MCP::JSONRPC::Request.new(
+        id => 1,
+        method => 'tools/call',
+        params => { name => 'slow-add', arguments => { a => 1, b => 1 }, task => { ttl => 5000 } }
+    ));
+    my $task-id = $create<task><taskId>;
+
+    # Wait for completion
+    sleep 0.3;
+
+    my @notifs = $transport.sent.grep({
+        $_ ~~ MCP::JSONRPC::Notification && .method eq 'notifications/tasks/status'
+    });
+    ok @notifs.elems >= 1, 'Status notification emitted on completion';
+    my $notif-params = @notifs[0].params;
+    is $notif-params<taskId>, $task-id, 'Notification has correct taskId';
+    is $notif-params<status>, 'completed', 'Notification shows completed';
+};
+
+subtest 'Task capabilities in server', {
+    my ($server, $transport) = make-server();
+
+    my $caps = $server.capabilities.Hash;
+    ok $caps<tasks>:exists, 'Server capabilities include tasks';
+    ok $caps<tasks><list>:exists, 'tasks.list capability';
+    ok $caps<tasks><cancel>:exists, 'tasks.cancel capability';
+    ok $caps<tasks><requests><tools><call>:exists, 'tasks.requests.tools.call capability';
+};
+
+subtest 'Tool builder task-support', {
+    my $tool = tool()
+        .name('async-tool')
+        .description('An async tool')
+        .handler(-> { 'ok' })
+        .task-support('required')
+        .build;
+
+    my $listing = $tool.to-tool;
+    ok $listing.execution.defined, 'Tool has execution';
+    is $listing.execution.taskSupport, MCP::Types::TaskRequired, 'taskSupport is required';
+    is $listing.Hash<execution><taskSupport>, 'required', 'Hash includes execution';
+};
+
+subtest 'tasks/get unknown task errors', {
+    my ($server, $transport) = make-server();
+
+    dies-ok {
+        $server.dispatch-request(MCP::JSONRPC::Request.new(
+            id => 1,
+            method => 'tasks/get',
+            params => { taskId => 'nonexistent' }
+        ));
+    }, 'Unknown task raises error';
+};
+
+subtest 'ServerCapabilities tasks roundtrip', {
+    my $caps = MCP::Types::ServerCapabilities.new(
+        tasks => { list => {}, cancel => {} },
+    );
+    my %h = $caps.Hash;
+    ok %h<tasks>:exists, 'Hash includes tasks';
+
+    my $caps2 = MCP::Types::ServerCapabilities.from-hash(%h);
+    ok $caps2.tasks.defined, 'from-hash restores tasks';
+    ok $caps2.tasks<list>:exists, 'tasks.list restored';
+};
+
+done-testing;


### PR DESCRIPTION
Add the experimental Tasks framework from MCP 2025-11-25, enabling async tool execution with status polling, blocking result retrieval, cancellation, and listing.