### PR TITLE
Implement Extensions framework

### DIFF
--- a/GAP_ANALYSIS.md
+++ b/GAP_ANALYSIS.md
@@ -16,7 +16,7 @@ This document compares the current implementation of the Raku MCP SDK against th
 | **Client Features** | ✅ Done | Sampling with tools, includeContext, stopReason, completion |
 | **Utilities** | ⚠️ Partial | Logging, progress, cancellation implemented |
 | **Authorization** | ✅ Done | OAuth 2.1 with PKCE |
-| **New 2025-11-25 Features** | ⚠️ Partial | Elicitation + Tasks + Sampling-with-tools done; Extensions missing |
+| **New 2025-11-25 Features** | ✅ Mostly Complete | Elicitation, Tasks, Sampling-with-tools, Extensions done |
 
 ---
 
@@ -256,6 +256,7 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 | Tasks | ✅ Experimental | ✅ Done (experimental) |
 | Completion | ✅ Full | ✅ Full |
 | Pagination | ✅ Full | ✅ Full |
+| Extensions | ✅ Experimental | ✅ Done (experimental) |
 
 ---
 
@@ -276,7 +277,7 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 
 ### Lower Priority (Advanced Features)
 10. ~~**Tasks framework**~~ ✅ **Done** - Long-running operations (experimental)
-11. **Extensions framework** - Plugin architecture
+11. ~~**Extensions framework**~~ ✅ **Done** - Extension registration, dispatch, capability negotiation
 12. ~~**Sampling with tools**~~ ✅ **Done** - Tools, toolChoice, includeContext, stopReason
 
 ---
@@ -286,9 +287,7 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 Current implementation targets: **2025-11-25** ✅
 
 Key features still needed for full 2025-11-25 compliance:
-- Add Extensions framework
 - Implement authorization extensions (SEP-1046, SEP-990)
-- Update capability negotiation for new features
 
 ---
 
@@ -298,15 +297,18 @@ Current tests cover:
 - ✅ Types serialization
 - ✅ JSON-RPC encoding/decoding
 - ✅ Builder patterns
-- ✅ Basic server/client lifecycle
+- ✅ Transport interface
+- ✅ Server dispatch and lifecycle
+- ✅ Client initialization
+- ✅ Top-level MCP exports
 - ✅ Sampling validation
+- ✅ HTTP transport
+- ✅ OAuth 2.1 types, PKCE, server/client handlers
+- ✅ Tasks framework (async tools, polling, cancellation)
+- ✅ Extensions framework (registration, dispatch, capabilities)
 
 Missing tests for:
-- ✅ Resource subscriptions - **Implemented**
-- ✅ Pagination - **Implemented**
-- ✅ Cancellation - **Implemented**
 - ❌ Progress tracking
-- ❌ HTTP transport (partial)
 - ❌ Error edge cases
 - ❌ Concurrent operations
 
@@ -314,12 +316,13 @@ Missing tests for:
 
 ## Conclusion
 
-The Raku MCP SDK provides a solid foundation with core protocol support, but significant work remains to achieve full specification compliance. The highest impact improvements would be:
+The Raku MCP SDK provides comprehensive MCP specification coverage. Remaining gaps are:
 
-1. Completing HTTP transport for production deployment
-2. ~~Adding resource subscriptions for real-time updates~~ ✅ **Done**
-3. ~~Implementing pagination for scalability~~ ✅ **Done**
-4. ~~Adding roots support for filesystem servers~~ ✅ **Done**
-5. ~~Implementing the authorization framework for secure connections~~ ✅ **Done**
+- Resource templates (URI templates with placeholders)
+- `notifications/prompts/list_changed`
+- `logging/setLevel` request handling
+- Dynamic client registration (OAuth)
+- Authorization extensions (SEP-1046, SEP-990)
+- SSE transport (legacy)
 
 The SDK's architecture is well-designed and should accommodate these additions without major refactoring.

--- a/GAP_ANALYSIS.md
+++ b/GAP_ANALYSIS.md
@@ -12,11 +12,11 @@ This document compares the current implementation of the Raku MCP SDK against th
 |----------|--------|-------|
 | **Base Protocol** | ✅ Mostly Complete | JSON-RPC 2.0, lifecycle, basic message handling |
 | **Transports** | ✅ Mostly Complete | Stdio complete, Streamable HTTP complete |
-| **Server Features** | ⚠️ Partial | Tools/Resources/Prompts basic support |
-| **Client Features** | ✅ Done | Sampling with tools, includeContext, stopReason |
+| **Server Features** | ✅ Mostly Complete | Tools/Resources/Prompts + pagination; missing resource templates and prompts list_changed |
+| **Client Features** | ✅ Done | Sampling with tools, includeContext, stopReason, completion |
 | **Utilities** | ⚠️ Partial | Logging, progress, cancellation implemented |
 | **Authorization** | ✅ Done | OAuth 2.1 with PKCE |
-| **New 2025-11-25 Features** | ⚠️ Partial | Elicitation done, Tasks/Extensions missing |
+| **New 2025-11-25 Features** | ⚠️ Partial | Elicitation + Tasks + Sampling-with-tools done; Extensions missing |
 
 ---
 
@@ -52,7 +52,6 @@ This document compares the current implementation of the Raku MCP SDK against th
 #### ⚠️ Partial
 - **Lifecycle**: Initialize/initialized handshake works, but:
   - Missing proper version negotiation (server should respond with supported version if client's isn't supported)
-  - Missing `instructions` parsing from server in client
   
 #### ❌ Missing
 - **JSON-RPC batching**: Not supported (though removed in 2025-06-18, re-evaluate if needed)
@@ -174,11 +173,9 @@ This document compares the current implementation of the Raku MCP SDK against th
 - Both sides have `cancel-request` method for explicit cancellation
 - `is-cancelled` method for handlers to check cancellation status
 
-#### ❌ Ping
+#### ✅ Ping
 - Server responds to `ping` requests
-- Missing:
-  - Client-side `ping` for keepalive
-  - Timeout handling
+- Client has `ping()` helper
 
 #### ✅ Completion (autocomplete)
 - `completion/complete` request handling
@@ -219,10 +216,12 @@ Long-running operation support:
 - `notifications/tasks/status` on state changes
 - Tool-level `execution.taskSupport` via builder
 
-#### ❌ Extensions Framework
-- Extension capability negotiation
-- Extension settings
-- Namespaced extension methods
+#### ✅ Extensions Framework
+- Extension capability negotiation via `experimental` hash
+- Extension settings and versioning
+- Namespaced extension methods and notification dispatch
+- Server: `register-extension()`, `unregister-extension()`
+- Client: `register-extension()`, `server-extensions()`, `supports-extension()`
 
 #### ❌ Authorization Extensions
 - SEP-1046: OAuth client credentials (M2M)
@@ -233,7 +232,7 @@ Long-running operation support:
 - `notify-elicitation-complete()` for completion notifications
 - `URLElicitationRequired` error code (-32042)
 
-#### ❌ Sampling with Tools (SEP-1577)
+#### ✅ Sampling with Tools (SEP-1577)
 - Tool definitions in sampling requests
 - Server-side agentic loops
 
@@ -245,9 +244,9 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 
 | Feature | Python SDK | Raku SDK |
 |---------|-----------|----------|
-| Tools | ✅ Full | ⚠️ Basic + annotations |
+| Tools | ✅ Full | ✅ Full + annotations |
 | Resources | ✅ Full + templates + subscriptions | ✅ Full + subscriptions (no templates) |
-| Prompts | ✅ Full | ⚠️ Basic |
+| Prompts | ✅ Full | ✅ Full (no list_changed notification) |
 | Sampling | ✅ Full + tools | ✅ Full + tools |
 | Roots | ✅ Full | ✅ Full |
 | Elicitation | ✅ Full + URL mode | ✅ Full |
@@ -255,7 +254,7 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 | Streamable HTTP | ✅ Full client + server | ✅ Full |
 | SSE Transport | ✅ Full | ❌ No |
 | Tasks | ✅ Experimental | ✅ Done (experimental) |
-| Completion | ✅ Full | ❌ No |
+| Completion | ✅ Full | ✅ Full |
 | Pagination | ✅ Full | ✅ Full |
 
 ---
@@ -276,7 +275,7 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 9. ~~**Implement OAuth 2.1**~~ ✅ **Done** - PKCE, token management, server validation
 
 ### Lower Priority (Advanced Features)
-10. **Tasks framework** - Long-running operations (experimental)
+10. ~~**Tasks framework**~~ ✅ **Done** - Long-running operations (experimental)
 11. **Extensions framework** - Plugin architecture
 12. ~~**Sampling with tools**~~ ✅ **Done** - Tools, toolChoice, includeContext, stopReason
 
@@ -288,6 +287,7 @@ Current implementation targets: **2025-11-25** ✅
 
 Key features still needed for full 2025-11-25 compliance:
 - Add Extensions framework
+- Implement authorization extensions (SEP-1046, SEP-990)
 - Update capability negotiation for new features
 
 ---

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.14.0",
+    "version": "0.15.0",
     "perl": "6.d",
     "auth": "github:wkusnierczyk",
     "license": "MIT",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.14.0
+VERSION         := 0.15.0
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk

--- a/Makefile
+++ b/Makefile
@@ -665,10 +665,6 @@ ifneq ($(TAG),)
 		printf "$(CLR_RED)✗ Version must be semver: MAJOR.MINOR.PATCH$(CLR_RESET)\n" >&2; \
 		exit 1; \
 	fi
-	@if git rev-parse -q --verify "refs/tags/v$(TAG)" >/dev/null; then \
-		printf "$(CLR_RED)✗ Tag v$(TAG) already exists$(CLR_RESET)\n" >&2; \
-		exit 1; \
-	fi
 	$(call log-info,Updating project version to $(TAG)...)
 	$(Q)perl -0pi -e 's/^(\s*VERSION\s*:=\s*).*/$${1}$(TAG)/m' Makefile
 	$(Q)perl -0pi -e 's/"version"\s*:\s*"[^"]*"/"version": "$(TAG)"/' $(META_FILE)
@@ -686,9 +682,6 @@ ifneq ($(TAG),)
 		exit 1; \
 	fi
 	$(call log-success,Version updated in Makefile, $(META_FILE), and README.md)
-	$(call log-info,Creating git tag v$(TAG)...)
-	$(Q)git tag -a "v$(TAG)" -m "$(DESCRIPTION)"
-	$(call log-success,Tag created locally: v$(TAG))
 else
 	$(call log,$(PROJECT_NAME) v$(VERSION))
 endif

--- a/README.md
+++ b/README.md
@@ -441,10 +441,10 @@ make test        # Run test suite
     <tr><td><code>ci</code></td><td>CI pipeline</td><td><code>dependencies → lint → test</code></td></tr>
     <tr><td><code>ci-full</code></td><td>Full CI pipeline</td><td><code>dependencies-dev → lint → test → coverage</code></td></tr>
     <tr><th colspan="3" align="left">Version management</th></tr>
-    <tr><td><code>version</code></td><td>Show or update project version</td><td><code>make TAG=1.2.3 DESCRIPTION="Release description" version</code> updates Makefile + META6.json + README and creates a local annotated tag</td></tr>
-    <tr><td><code>bump-patch</code></td><td>Patch bump</td><td><code>make bump-patch</code> bumps to the next patch version and tags it</td></tr>
-    <tr><td><code>bump-minor</code></td><td>Minor bump</td><td><code>make bump-minor</code> bumps to the next minor version and tags it</td></tr>
-    <tr><td><code>bump-major</code></td><td>Major bump</td><td><code>make bump-major</code> bumps to the next major version and tags it</td></tr>
+    <tr><td><code>version</code></td><td>Show or update project version</td><td><code>make TAG=1.2.3 DESCRIPTION="Release description" version</code> updates Makefile + META6.json + README (no tag)</td></tr>
+    <tr><td><code>bump-patch</code></td><td>Patch bump</td><td><code>make bump-patch</code> bumps to the next patch version (no tag)</td></tr>
+    <tr><td><code>bump-minor</code></td><td>Minor bump</td><td><code>make bump-minor</code> bumps to the next minor version (no tag)</td></tr>
+    <tr><td><code>bump-major</code></td><td>Major bump</td><td><code>make bump-major</code> bumps to the next major version (no tag)</td></tr>
     <tr><th colspan="3" align="left">Cleaning</th></tr>
     <tr><td><code>clean</code></td><td>Remove build/coverage/dist</td><td>Runs clean-build/clean-coverage/clean-dist</td></tr>
     <tr><td><code>clean-build</code></td><td>Remove precomp/build dirs</td><td>Removes <code>.precomp</code> and <code>.build</code></td></tr>
@@ -465,7 +465,7 @@ make test        # Run test suite
 
 ### Versioning
 
-Use `make version` to set an explicit version and create a local annotated tag (no push):
+Use `make version` to set an explicit version (no tag):
 
 ```bash
 make TAG=0.10.0 DESCRIPTION="Release description" version

--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ Building this repository was supported by:
 $ make about
 
 Raku MCP SDK: Raku Implementation of the Model Context Protocol
-├─ version:    0.14.0
+├─ version:    0.15.0
 ├─ developer:  mailto:waclaw.kusnierczyk@gmail.com
 ├─ source:     https://github.com/wkusnierczyk/raku-mcp-sdk
 └─ licence:    MIT https://opensource.org/licenses/MIT

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See [Gap Analysis](GAP_ANALYSIS.md) for details on implemented and missing featu
 | HTTP Transport | ✅ Done | Full client/server with session management, SSE, resumption |
 | Elicitation | ✅ Done | Form and URL modes with handler callbacks |
 | Tasks (experimental) | ✅ Done | Async tool execution, status polling, cancellation |
-| Extensions framework | ❌ Planned | |
+| Extensions framework | ✅ Done (experimental) | Negotiation via `experimental` capabilities + extension method routing |
 | Completion | ✅ Done | Prompt and resource autocomplete with handler registration |
 | Tool output schemas | ✅ Done | `outputSchema` and `structuredContent` for structured results |
 | Tool metadata | ❌ Planned | icon metadata + tool name validation guidance |

--- a/lib/MCP.rakumod
+++ b/lib/MCP.rakumod
@@ -56,6 +56,7 @@ constant CreateMessageResult is export = MCP::Types::CreateMessageResult;
 constant Task is export = MCP::Types::Task;
 constant TaskStatus is export = MCP::Types::TaskStatus;
 constant CreateTaskResult is export = MCP::Types::CreateTaskResult;
+constant Extension is export = MCP::Types::Extension;
 
 #| Re-exported log level constants
 constant Debug is export = MCP::Types::Debug;

--- a/lib/MCP/Types.rakumod
+++ b/lib/MCP/Types.rakumod
@@ -551,9 +551,30 @@ class CompletionResult is export {
     }
 }
 
+#| Extension definition for experimental capabilities
+class Extension is export {
+    has Str $.name is required;
+    has Str $.version;
+    has Hash $.settings;
+
+    method Hash(--> Hash) {
+        my %h = name => $!name;
+        %h<version> = $_ with $!version;
+        %h<settings> = $_ with $!settings;
+        %h
+    }
+
+    method from-hash(%h --> Extension) {
+        my %args = name => %h<name>;
+        %args<version> = %h<version> if %h<version>.defined;
+        %args<settings> = %h<settings> if %h<settings>.defined;
+        self.new(|%args)
+    }
+}
+
 #| Full server capabilities
 class ServerCapabilities is export {
-    has Bool $.experimental;
+    has Hash $.experimental;
     has LoggingCapability $.logging;
     has PromptsCapability $.prompts;
     has ResourcesCapability $.resources;
@@ -563,7 +584,7 @@ class ServerCapabilities is export {
 
     method Hash(--> Hash) {
         my %h;
-        %h<experimental> = {} if $!experimental;
+        %h<experimental> = $!experimental if $!experimental;
         %h<logging> = $!logging.Hash if $!logging;
         %h<prompts> = $!prompts.Hash if $!prompts;
         %h<resources> = $!resources.Hash if $!resources;
@@ -575,7 +596,7 @@ class ServerCapabilities is export {
 
     method from-hash(%h --> ServerCapabilities) {
         my %args;
-        %args<experimental> = %h<experimental>.defined;
+        %args<experimental> = %h<experimental> if %h<experimental>.defined && %h<experimental> ~~ Hash;
         %args<logging> = %h<logging> ?? LoggingCapability.new !! LoggingCapability;
         %args<prompts> = %h<prompts> ?? PromptsCapability.new(|%h<prompts>) !! PromptsCapability;
         %args<resources> = %h<resources> ?? ResourcesCapability.new(|%h<resources>) !! ResourcesCapability;
@@ -684,7 +705,7 @@ class ElicitationResponse is export {
 
 #| Full client capabilities
 class ClientCapabilities is export {
-    has Bool $.experimental;
+    has Hash $.experimental;
     has RootsCapability $.roots;
     has SamplingCapability $.sampling;
     has ElicitationCapability $.elicitation;
@@ -692,7 +713,7 @@ class ClientCapabilities is export {
 
     method Hash(--> Hash) {
         my %h;
-        %h<experimental> = {} if $!experimental;
+        %h<experimental> = $!experimental if $!experimental;
         %h<roots> = $!roots.Hash if $!roots;
         %h<sampling> = $!sampling.Hash if $!sampling;
         %h<elicitation> = $!elicitation.Hash if $!elicitation;

--- a/t/01-types.rakutest
+++ b/t/01-types.rakutest
@@ -598,7 +598,7 @@ subtest 'ToolChoice Hash', {
 # Test ServerCapabilities from-hash roundtrip
 subtest 'ServerCapabilities from-hash', {
     my $caps = ServerCapabilities.new(
-        experimental => True,
+        experimental => { 'test/ext' => {} },
         logging => LoggingCapability.new,
         prompts => PromptsCapability.new(listChanged => True),
         resources => ResourcesCapability.new(subscribe => True, listChanged => True),

--- a/t/01-types.rakutest
+++ b/t/01-types.rakutest
@@ -16,7 +16,7 @@ use lib 'lib';
 
 use MCP::Types;
 
-plan 31;
+plan 41;
 
 # Test Implementation
 subtest 'Implementation', {
@@ -455,6 +455,164 @@ subtest 'ElicitationResponse', {
     });
     is $restored.action, ElicitAccept, 'from-hash restores accept';
     is $restored.content<email>, 'test@example.com', 'from-hash restores content';
+};
+
+# Test ImageContent Hash serialization
+subtest 'ImageContent Hash', {
+    my $img = ImageContent.new(data => 'abc123', mimeType => 'image/png');
+    my %h = $img.Hash;
+    is %h<type>, 'image', 'type is image';
+    is %h<data>, 'abc123', 'data preserved';
+    is %h<mimeType>, 'image/png', 'mimeType preserved';
+    nok %h<annotations>:exists, 'no annotations when not set';
+
+    my $with-ann = ImageContent.new(
+        data => 'x', mimeType => 'image/jpeg',
+        annotations => Annotations.new(audience => ['user'], priority => 0.8e0),
+    );
+    my %h2 = $with-ann.Hash;
+    ok %h2<annotations>:exists, 'annotations included';
+    is %h2<annotations><priority>, 0.8e0, 'annotation priority';
+};
+
+# Test AudioContent Hash serialization
+subtest 'AudioContent Hash', {
+    my $audio = AudioContent.new(data => 'audiodata', mimeType => 'audio/wav');
+    my %h = $audio.Hash;
+    is %h<type>, 'audio', 'type is audio';
+    is %h<data>, 'audiodata', 'data preserved';
+    is %h<mimeType>, 'audio/wav', 'mimeType preserved';
+
+    my $with-ann = AudioContent.new(
+        data => 'x', mimeType => 'audio/mp3',
+        annotations => Annotations.new(audience => ['assistant']),
+    );
+    ok $with-ann.Hash<annotations>:exists, 'annotations included';
+};
+
+# Test EmbeddedResource Hash serialization
+subtest 'EmbeddedResource Hash', {
+    my $rc = ResourceContents.new(uri => 'file:///test', mimeType => 'text/plain', text => 'hi');
+    my $er = EmbeddedResource.new(resource => $rc);
+    my %h = $er.Hash;
+    is %h<type>, 'resource', 'type is resource';
+    is %h<resource><uri>, 'file:///test', 'resource uri';
+    nok %h<annotations>:exists, 'no annotations';
+
+    my $with-ann = EmbeddedResource.new(
+        resource => $rc,
+        annotations => Annotations.new(priority => 0.3e0),
+    );
+    ok $with-ann.Hash<annotations>:exists, 'annotations included';
+};
+
+# Test ResourceLink Hash serialization
+subtest 'ResourceLink Hash', {
+    my $rl = ResourceLink.new(name => 'doc', uri => 'file:///doc.pdf',
+        title => 'Doc', description => 'A doc', mimeType => 'application/pdf', size => 1024);
+    my %h = $rl.Hash;
+    is %h<type>, 'resource_link', 'type';
+    is %h<name>, 'doc', 'name';
+    is %h<uri>, 'file:///doc.pdf', 'uri';
+    is %h<title>, 'Doc', 'title';
+    is %h<description>, 'A doc', 'description';
+    is %h<mimeType>, 'application/pdf', 'mimeType';
+    is %h<size>, 1024, 'size';
+
+    # Minimal
+    my $min = ResourceLink.new(name => 'x', uri => 'y');
+    my %h2 = $min.Hash;
+    nok %h2<title>:exists, 'no title';
+    nok %h2<size>:exists, 'no size';
+};
+
+# Test ToolUseContent Hash
+subtest 'ToolUseContent Hash', {
+    my $tu = ToolUseContent.new(id => 'call-1', name => 'calc', input => { expr => '1+1' });
+    my %h = $tu.Hash;
+    is %h<type>, 'tool_use', 'type';
+    is %h<id>, 'call-1', 'id';
+    is %h<name>, 'calc', 'name';
+    is %h<input><expr>, '1+1', 'input';
+};
+
+# Test ToolResultContent Hash
+subtest 'ToolResultContent Hash', {
+    my $tr = ToolResultContent.new(
+        toolUseId => 'call-1',
+        content => [TextContent.new(text => 'result')],
+        isError => True,
+        structuredContent => { val => 42 },
+        meta => { requestId => 'r1' },
+    );
+    my %h = $tr.Hash;
+    is %h<type>, 'tool_result', 'type';
+    is %h<toolUseId>, 'call-1', 'toolUseId';
+    ok %h<isError>, 'isError';
+    is %h<structuredContent><val>, 42, 'structuredContent';
+    is %h<_meta><requestId>, 'r1', 'meta';
+    is %h<content>[0]<type>, 'text', 'content serialized';
+};
+
+# Test ModelHint Hash
+subtest 'ModelHint Hash', {
+    my $hint = ModelHint.new(name => 'claude-3');
+    my %h = $hint.Hash;
+    is %h<name>, 'claude-3', 'name in Hash';
+};
+
+# Test ModelPreferences Hash
+subtest 'ModelPreferences Hash', {
+    my $prefs = ModelPreferences.new(
+        hints => [ModelHint.new(name => 'fast')],
+        costPriority => 0.5e0,
+        speedPriority => 0.8e0,
+        intelligencePriority => 0.3e0,
+    );
+    my %h = $prefs.Hash;
+    is %h<hints>[0]<name>, 'fast', 'hint name';
+    is %h<costPriority>, 0.5e0, 'costPriority';
+    is %h<speedPriority>, 0.8e0, 'speedPriority';
+    is %h<intelligencePriority>, 0.3e0, 'intelligencePriority';
+
+    # Minimal
+    my $min = ModelPreferences.new;
+    my %h2 = $min.Hash;
+    nok %h2<hints>:exists, 'no hints';
+    nok %h2<costPriority>:exists, 'no costPriority';
+};
+
+# Test ToolChoice Hash
+subtest 'ToolChoice Hash', {
+    my $tc = ToolChoice.new(mode => 'tool', name => 'calc');
+    my %h = $tc.Hash;
+    is %h<mode>, 'tool', 'mode';
+    is %h<name>, 'calc', 'name';
+
+    my $auto = ToolChoice.new(mode => 'auto');
+    my %h2 = $auto.Hash;
+    is %h2<mode>, 'auto', 'auto mode';
+    nok %h2<name>:exists, 'no name for auto';
+};
+
+# Test ServerCapabilities from-hash roundtrip
+subtest 'ServerCapabilities from-hash', {
+    my $caps = ServerCapabilities.new(
+        experimental => True,
+        logging => LoggingCapability.new,
+        prompts => PromptsCapability.new(listChanged => True),
+        resources => ResourcesCapability.new(subscribe => True, listChanged => True),
+        tools => ToolsCapability.new(listChanged => True),
+        completions => CompletionsCapability.new,
+        tasks => { list => {} },
+    );
+    my %h = $caps.Hash;
+    ok %h<experimental>:exists, 'experimental in Hash';
+    ok %h<tasks>:exists, 'tasks in Hash';
+
+    my $restored = ServerCapabilities.from-hash(%h);
+    ok $restored.tools.defined, 'from-hash restores tools';
+    ok $restored.tasks.defined, 'from-hash restores tasks';
 };
 
 done-testing;

--- a/t/03-builders.rakutest
+++ b/t/03-builders.rakutest
@@ -178,6 +178,46 @@ subtest 'Resource builder and normalization', {
     is $file.mimeType, 'text/plain', 'file-resource guesses mime type';
     ok $file.uri.starts-with('file://'), 'file-resource sets uri';
 
+    # Test from-file MIME type guessing for various extensions
+    my $tmp-dir = $*TMPDIR;
+    for <html css js json xml png jpg jpeg gif svg pdf md> -> $ext {
+        my $f = $tmp-dir.add("mcp-test-$*PID.$ext");
+        $f.spurt("test");
+        my $fr = file-resource($f);
+        ok $fr.mimeType.defined, "from-file guesses mime for .$ext";
+        $f.unlink;
+    }
+
+    # Unknown extension falls back to octet-stream
+    my $unk = $tmp-dir.add("mcp-test-$*PID.xyz");
+    $unk.spurt("test");
+    my $fr-unk = file-resource($unk);
+    is $fr-unk.mimeType, 'application/octet-stream', 'unknown ext -> octet-stream';
+    $unk.unlink;
+
+    # from-file with custom uri/name overrides
+    my $f2 = $tmp-dir.add("mcp-test-$*PID.json");
+    $f2.spurt('{}');
+    my $custom = resource().from-file($f2.IO).uri('custom://x').name('Custom').build;
+    is $custom.uri, 'custom://x', 'from-file uri override';
+    is $custom.name, 'Custom', 'from-file name override';
+    is $custom.mimeType, 'application/json', 'from-file mime still guessed';
+    $f2.unlink;
+
+    # Resource reader returning arbitrary object (default fallback)
+    my $fallback-res = RegisteredResource.new(
+        uri => 'fb://', name => 'Fallback',
+        reader => { 42 }
+    );
+    is $fallback-res.read[0].text, '42', 'fallback normalizes to Str';
+
+    # ResourceContents reader
+    my $rc-res = RegisteredResource.new(
+        uri => 'rc://', name => 'RC',
+        reader => { MCP::Types::ResourceContents.new(uri => 'rc://', text => 'direct') }
+    );
+    is $rc-res.read[0].text, 'direct', 'ResourceContents preserved';
+
     dies-ok { resource().build }, 'resource requires uri';
     dies-ok { resource().uri('x').build }, 'resource requires name';
     dies-ok { resource().uri('x').name('y').build }, 'resource requires reader';
@@ -210,6 +250,34 @@ subtest 'Prompt builder and normalization', {
     my $assistant = assistant-message('a');
     is $user.role, 'user', 'user-message role';
     is $assistant.role, 'assistant', 'assistant-message role';
+
+    # required-argument with description
+    my $p3 = prompt()
+        .name('q')
+        .required-argument('name', description => 'Your name')
+        .generator(-> :%params { "Hi %params<name>" })
+        .build;
+    my $args = $p3.to-prompt.arguments;
+    is $args[0].name, 'name', 'required-argument name';
+    ok $args[0].required, 'required-argument is required';
+    is $args[0].description, 'Your name', 'required-argument description';
+
+    # Generator returning array of PromptMessage
+    my $p4 = RegisteredPrompt.new(
+        name => 'multi',
+        generator => {
+            [
+                MCP::Types::PromptMessage.new(role => 'user', content => MCP::Types::TextContent.new(text => 'a')),
+                MCP::Types::PromptMessage.new(role => 'assistant', content => MCP::Types::TextContent.new(text => 'b')),
+            ]
+        }
+    );
+    is $p4.get({})[0].content.text, 'a', 'array of PromptMessage first';
+    is $p4.get({})[1].content.text, 'b', 'array of PromptMessage second';
+
+    # Generator returning non-string fallback
+    my $p5 = RegisteredPrompt.new(name => 'num', generator => { 99 });
+    is $p5.get({})[0].content.text, '99', 'non-string fallback';
 
     dies-ok { prompt().build }, 'prompt requires name';
     dies-ok { prompt().name('p').build }, 'prompt requires generator';

--- a/t/04-transport.rakutest
+++ b/t/04-transport.rakutest
@@ -85,6 +85,15 @@ subtest 'Transport error types', {
 
     my $send = MCP::Transport::Base::X::Transport::Send.new(message => 'nope');
     ok $send.message.contains('Send error'), 'send error prefix';
+
+    # cause property
+    my $with-cause = MCP::Transport::Base::X::Transport.new(message => 'fail', cause => 'root');
+    is $with-cause.cause, 'root', 'cause property set';
+
+    # Exception hierarchy
+    ok $conn ~~ MCP::Transport::Base::X::Transport, 'Connection is-a Transport error';
+    ok $send ~~ MCP::Transport::Base::X::Transport, 'Send is-a Transport error';
+    ok $conn ~~ Exception, 'Connection is-a Exception';
 };
 
 done-testing;

--- a/t/07-mcp.rakutest
+++ b/t/07-mcp.rakutest
@@ -42,6 +42,27 @@ subtest 'MCP exports', {
         .generator({ 'hi' })
         .build;
     is $prompt.name, 'p', 'prompt builder available';
+
+    # file-resource convenience
+    my $tmp = $*TMPDIR.add("mcp-export-test-$*PID.txt");
+    $tmp.spurt("exported");
+    my $fr = file-resource($tmp);
+    ok $fr.uri.starts-with('file://'), 'file-resource exported';
+    $tmp.unlink;
+
+    # Additional type exports
+    is ImageContent.^name, 'MCP::Types::ImageContent', 'ImageContent export';
+    is AudioContent.^name, 'MCP::Types::AudioContent', 'AudioContent export';
+    is ResourceLink.^name, 'MCP::Types::ResourceLink', 'ResourceLink export';
+    is ToolUseContent.^name, 'MCP::Types::ToolUseContent', 'ToolUseContent export';
+    is ToolResultContent.^name, 'MCP::Types::ToolResultContent', 'ToolResultContent export';
+    is ModelHint.^name, 'MCP::Types::ModelHint', 'ModelHint export';
+    is ModelPreferences.^name, 'MCP::Types::ModelPreferences', 'ModelPreferences export';
+    is ToolChoice.^name, 'MCP::Types::ToolChoice', 'ToolChoice export';
+    is CreateMessageResult.^name, 'MCP::Types::CreateMessageResult', 'CreateMessageResult export';
+    is Task.^name, 'MCP::Types::Task', 'Task export';
+    is CreateTaskResult.^name, 'MCP::Types::CreateTaskResult', 'CreateTaskResult export';
+    ok StdioTransport.^name.contains('Stdio'), 'StdioTransport export';
 };
 
 done-testing;

--- a/t/10-oauth.rakutest
+++ b/t/10-oauth.rakutest
@@ -5,7 +5,7 @@ use lib 'lib';
 use MCP::OAuth;
 use MCP::OAuth::Server;
 
-plan 7;
+plan 9;
 
 # === 1. PKCE ===
 subtest 'PKCE', {
@@ -120,7 +120,47 @@ subtest 'OAuthServerHandler', {
     ok $www.contains('Bearer'), 'www-authenticate starts with Bearer';
 };
 
-# === 6. OAuthClientHandler authorization-url ===
+# === 6. OAuthServerHandler scope header and Forbidden path ===
+subtest 'OAuthServerHandler www-authenticate-scope-header', {
+    plan 3;
+    my $handler = OAuthServerHandler.new(
+        resource-identifier => 'https://api.example.com',
+        authorization-servers => ['https://auth.example.com'],
+        scopes-supported => ['read', 'write'],
+        token-validator => -> Str $token { { valid => False, scopes => ['read', 'write'], message => 'Insufficient scope' } },
+    );
+
+    my $scope-header = $handler.www-authenticate-scope-header(['read', 'write']);
+    ok $scope-header.contains('Bearer'), 'scope header starts with Bearer';
+    ok $scope-header.contains('insufficient_scope'), 'scope header has error';
+    ok $scope-header.contains('read write'), 'scope header has scopes';
+};
+
+subtest 'OAuthServerHandler Forbidden with scopes', {
+    plan 2;
+    my $handler = OAuthServerHandler.new(
+        resource-identifier => 'https://api.example.com',
+        authorization-servers => ['https://auth.example.com'],
+        scopes-supported => ['admin'],
+        token-validator => -> Str $token {
+            { valid => False, scopes => ['admin'], message => 'Need admin' }
+        },
+    );
+
+    my $req = class { method header($n) { 'Bearer some-token' } }.new;
+    try {
+        $handler.validate-request($req);
+        CATCH {
+            when X::MCP::OAuth::Forbidden {
+                ok True, 'Forbidden exception thrown';
+                ok .message.contains('Need admin') || .message.contains('Insufficient'), 'Forbidden message';
+            }
+            default { flunk "Wrong exception: {.^name}" }
+        }
+    }
+};
+
+# === 7. OAuthClientHandler authorization-url ===
 subtest 'OAuthClientHandler authorization-url', {
     plan 3;
     use MCP::OAuth::Client;

--- a/t/12-extensions.rakutest
+++ b/t/12-extensions.rakutest
@@ -1,0 +1,156 @@
+use v6.d;
+use Test;
+use lib 'lib';
+use lib 't/lib';
+use MCP::Types;
+use MCP::Server;
+use MCP::Client;
+need MCP::JSONRPC;
+need TestTransport;
+
+plan 9;
+
+use MONKEY-TYPING;
+augment class MCP::Server::Server {
+    method handle-message-public($msg) { self!handle-message($msg) }
+}
+
+# === 1. Extension type ===
+subtest 'Extension type construct and roundtrip', {
+    plan 5;
+    my $ext = MCP::Types::Extension.new(name => 'acme/logging', version => '1.0', settings => { level => 'debug' });
+    is $ext.name, 'acme/logging', 'name';
+    is $ext.version, '1.0', 'version';
+    is $ext.settings<level>, 'debug', 'settings';
+
+    my %h = $ext.Hash;
+    my $ext2 = MCP::Types::Extension.from-hash(%h);
+    is $ext2.name, 'acme/logging', 'roundtrip name';
+    is $ext2.settings<level>, 'debug', 'roundtrip settings';
+};
+
+# === 2. ServerCapabilities with experimental Hash ===
+subtest 'ServerCapabilities experimental Hash serialization', {
+    plan 3;
+    my $caps = MCP::Types::ServerCapabilities.new(
+        experimental => { 'acme/ext' => { version => '1.0', settings => {} } }
+    );
+    my %h = $caps.Hash;
+    ok %h<experimental>:exists, 'experimental present in Hash';
+    is %h<experimental><acme/ext><version>, '1.0', 'extension data preserved';
+
+    my $caps2 = MCP::Types::ServerCapabilities.from-hash(%h);
+    is $caps2.experimental<acme/ext><version>, '1.0', 'roundtrip from-hash';
+};
+
+# === 3. Server register-extension appears in capabilities ===
+subtest 'Server register-extension in capabilities', {
+    plan 2;
+    my $transport = TestTransport::TestTransport.new;
+    my $server = MCP::Server::Server.new(
+        info => MCP::Types::Implementation.new(name => 'test', version => '0.1'),
+        transport => $transport,
+    );
+    $server.register-extension(
+        name     => 'acme/test',
+        version  => '2.0',
+        settings => { foo => 'bar' },
+    );
+    my $caps = $server.capabilities;
+    ok $caps.experimental.defined, 'experimental is set';
+    is $caps.experimental<acme/test><version>, '2.0', 'extension in capabilities';
+};
+
+# === 4. Server extension method dispatch ===
+subtest 'Server extension method dispatch', {
+    plan 1;
+    my $transport = TestTransport::TestTransport.new;
+    my $server = MCP::Server::Server.new(
+        info => MCP::Types::Implementation.new(name => 'test', version => '0.1'),
+        transport => $transport,
+    );
+    $server.register-extension(
+        name    => 'acme/math',
+        methods => { 'acme/math.add' => -> %params { { sum => %params<a> + %params<b> } } },
+    );
+
+    my $req = MCP::JSONRPC::Request.new(id => 1, method => 'acme/math.add', params => { a => 3, b => 4 });
+    my $result = $server.dispatch-request($req);
+    is $result<sum>, 7, 'extension method handler called';
+};
+
+# === 5. Server extension notification dispatch ===
+subtest 'Server extension notification dispatch', {
+    plan 1;
+    my $transport = TestTransport::TestTransport.new;
+    my $server = MCP::Server::Server.new(
+        info => MCP::Types::Implementation.new(name => 'test', version => '0.1'),
+        transport => $transport,
+    );
+    my $called = False;
+    $server.register-extension(
+        name          => 'acme/events',
+        notifications => { 'acme/events.ping' => -> %params { $called = True } },
+    );
+
+    my $notif = MCP::JSONRPC::Notification.new(method => 'acme/events.ping', params => {});
+    $server.handle-message-public($notif);
+    ok $called, 'extension notification handler called';
+};
+
+# === 6. Server unregister-extension ===
+subtest 'Server unregister-extension', {
+    plan 2;
+    my $transport = TestTransport::TestTransport.new;
+    my $server = MCP::Server::Server.new(
+        info => MCP::Types::Implementation.new(name => 'test', version => '0.1'),
+        transport => $transport,
+    );
+    $server.register-extension(name => 'acme/temp', version => '1.0');
+    ok $server.capabilities.experimental<acme/temp>:exists, 'registered';
+    $server.unregister-extension('acme/temp');
+    my $caps = $server.capabilities;
+    my $still-there = $caps.experimental.defined && ($caps.experimental<acme/temp>:exists);
+    ok !$still-there, 'unregistered';
+};
+
+# === 7. Client register-extension ===
+subtest 'Client register-extension in init capabilities', {
+    plan 1;
+    my $client = MCP::Client::Client.new(
+        info => MCP::Types::Implementation.new(name => 'test-client', version => '0.1'),
+        transport => TestTransport::TestTransport.new,
+    );
+    $client.register-extension(name => 'acme/feature', version => '1.0', settings => { enabled => True });
+    pass 'client extension registered without error';
+};
+
+# === 8. Client server-extensions ===
+subtest 'Client server-extensions parses experimental', {
+    plan 2;
+    my $client = MCP::Client::Client.new(
+        info => MCP::Types::Implementation.new(name => 'test-client', version => '0.1'),
+        transport => TestTransport::TestTransport.new,
+    );
+    is $client.server-extensions.elems, 0, 'no server extensions before connect';
+    ok !$client.supports-extension('acme/foo'), 'supports-extension returns False';
+};
+
+# === 9. Namespace validation ===
+subtest 'Extension name must contain /', {
+    plan 2;
+    my $transport = TestTransport::TestTransport.new;
+    my $server = MCP::Server::Server.new(
+        info => MCP::Types::Implementation.new(name => 'test', version => '0.1'),
+        transport => $transport,
+    );
+    dies-ok { $server.register-extension(name => 'badname') }, 'server rejects name without /';
+
+    my $client = MCP::Client::Client.new(
+        info => MCP::Types::Implementation.new(name => 'test-client', version => '0.1'),
+        transport => TestTransport::TestTransport.new,
+    );
+    dies-ok { $client.register-extension(name => 'badname') }, 'client rejects name without /';
+};
+
+done-testing;


### PR DESCRIPTION
## Summary
Implement the extensions framework for optional protocol features.

## Background
Extensions allow the MCP ecosystem to grow without bloating the core specification. Extensions are namespaced, negotiated during initialization, and can have their own settings.

## Requirements

### Capability Negotiation
- Declare supported extensions in capabilities
- Negotiate extension versions
- Exchange extension settings

### Extension Registration
- API for registering custom extensions
- Namespace validation
- Method routing for extension methods

### Built-in Extensions Support
- Authorization extensions (SEP-1046, SEP-990)
- MCP Apps extension (SEP-1865) - future

### Types
- `Extension` with name, version, settings
- Extension capability declaration

## Example
```raku
my $server = Server.new(...);
$server.register-extension(
  name => 'example/myext',
  version => '1.0',
  methods => {
    'example/myext/action' => &handle-action
  }
);
```

## References
- [MCP Specification 2025-11-25 - Extensions](https://modelcontextprotocol.io/specification/2025-11-25)