### PR TITLE
Tool icon metadata

### DIFF
--- a/GAP_ANALYSIS.md
+++ b/GAP_ANALYSIS.md
@@ -256,8 +256,7 @@ The [official Python SDK](https://github.com/modelcontextprotocol/python-sdk) im
 
 All priority items from the original roadmap have been completed. Remaining items:
 
-1. **Tool icon metadata** — Tool `icon` field not yet implemented
-2. **Test coverage** — Missing tests for progress tracking, error edge cases, concurrent operations
+1. **Test coverage** — Missing tests for progress tracking, error edge cases, concurrent operations
 
 ---
 
@@ -296,4 +295,4 @@ Areas with limited test coverage:
 
 ## Conclusion
 
-The Raku MCP SDK provides comprehensive MCP specification 2025-11-25 coverage. All transport types (Stdio, Streamable HTTP, Legacy SSE), all server features (Tools, Resources, Prompts), all client features (Sampling, Roots, Elicitation, Completion), and full OAuth 2.1 authorization are implemented. Remaining work is limited to tool icon metadata and expanded test coverage.
+The Raku MCP SDK provides comprehensive MCP specification 2025-11-25 coverage. All transport types (Stdio, Streamable HTTP, Legacy SSE), all server features (Tools, Resources, Prompts), all client features (Sampling, Roots, Elicitation, Completion), and full OAuth 2.1 authorization are implemented. Remaining work is limited to expanded test coverage.

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.26.1",
+    "version": "0.27.0",
     "perl": "6.d",
     "auth": "github:wkusnierczyk",
     "license": "MIT",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.26.1
+VERSION         := 0.27.0
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk

--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ Building this repository was supported by:
 $ make about
 
 Raku MCP SDK: Raku Implementation of the Model Context Protocol
-├─ version:    0.26.1
+├─ version:    0.27.0
 ├─ developer:  mailto:waclaw.kusnierczyk@gmail.com
 ├─ source:     https://github.com/wkusnierczyk/raku-mcp-sdk
 └─ licence:    MIT https://opensource.org/licenses/MIT

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Raku MCP SDK provides comprehensive coverage of the [MCP specification 2025-11-2
 | Completion | ✅ Done | Prompt and resource autocomplete with handler registration |
 | Tool output schemas | ✅ Done | `outputSchema` and `structuredContent` for structured results |
 | Resource templates | ✅ Done | URI templates with pattern matching and builder API |
-| Tool metadata | ⚠️ Partial | Tool name validation (SEP-986); icon metadata not yet implemented |
+| Tool metadata | ✅ Done | Tool name validation (SEP-986), icons and title on Tool/Resource/Prompt/Implementation (SEP-973) |
 | OAuth 2.1 | ✅ Done | PKCE, token management, server validation, metadata discovery, dynamic client registration, M2M client credentials, enterprise IdP (SEP-990) |
 
 ## Table of contents

--- a/lib/MCP/Server/Prompt.rakumod
+++ b/lib/MCP/Server/Prompt.rakumod
@@ -20,6 +20,8 @@ use MCP::Types;
 class RegisteredPrompt is export {
     has Str $.name is required;
     has Str $.description;
+    has Str $.title;
+    has @.icons;
     has @.arguments;  # Array of PromptArgument
     has &.generator is required;
 
@@ -28,6 +30,8 @@ class RegisteredPrompt is export {
         MCP::Types::Prompt.new(
             name => $!name,
             description => $!description,
+            title => $!title,
+            icons => @!icons,
             arguments => @!arguments,
         )
     }
@@ -96,6 +100,8 @@ class RegisteredPrompt is export {
 class PromptBuilder is export {
     has Str $!name;
     has Str $!description;
+    has Str $!title;
+    has @!icons;
     has @!arguments;
     has &!generator;
 
@@ -106,6 +112,16 @@ class PromptBuilder is export {
 
     method description(Str $desc --> PromptBuilder) {
         $!description = $desc;
+        self
+    }
+
+    method title(Str $t --> PromptBuilder) {
+        $!title = $t;
+        self
+    }
+
+    method icon(Str $src, Str :$mimeType, :@sizes --> PromptBuilder) {
+        @!icons.push(MCP::Types::IconDefinition.new(:$src, :$mimeType, :@sizes));
         self
     }
 
@@ -139,6 +155,8 @@ class PromptBuilder is export {
         RegisteredPrompt.new(
             name => $!name,
             description => $!description,
+            title => $!title,
+            icons => @!icons,
             arguments => @!arguments,
             generator => &!generator,
         )

--- a/lib/MCP/Server/Resource.rakumod
+++ b/lib/MCP/Server/Resource.rakumod
@@ -22,6 +22,8 @@ class RegisteredResource is export {
     has Str $.uri is required;
     has Str $.name is required;
     has Str $.description;
+    has Str $.title;
+    has @.icons;
     has Str $.mimeType;
     has MCP::Types::Annotations $.annotations;
     has &.reader is required;
@@ -32,6 +34,8 @@ class RegisteredResource is export {
             uri => $!uri,
             name => $!name,
             description => $!description,
+            title => $!title,
+            icons => @!icons,
             mimeType => $!mimeType,
             annotations => $!annotations,
         )
@@ -79,6 +83,8 @@ class ResourceBuilder is export {
     has Str $!uri;
     has Str $!name;
     has Str $!description;
+    has Str $!title;
+    has @!icons;
     has Str $!mimeType;
     has MCP::Types::Annotations $!annotations;
     has &!reader;
@@ -95,6 +101,16 @@ class ResourceBuilder is export {
 
     method description(Str $desc --> ResourceBuilder) {
         $!description = $desc;
+        self
+    }
+
+    method title(Str $t --> ResourceBuilder) {
+        $!title = $t;
+        self
+    }
+
+    method icon(Str $src, Str :$mimeType, :@sizes --> ResourceBuilder) {
+        @!icons.push(MCP::Types::IconDefinition.new(:$src, :$mimeType, :@sizes));
         self
     }
 
@@ -149,6 +165,8 @@ class ResourceBuilder is export {
             uri => $!uri,
             name => $!name,
             description => $!description,
+            title => $!title,
+            icons => @!icons,
             mimeType => $!mimeType,
             annotations => $!annotations,
             reader => &!reader,
@@ -174,6 +192,8 @@ class RegisteredResourceTemplate is export {
     has Str $.uri-template is required;
     has Str $.name is required;
     has Str $.description;
+    has Str $.title;
+    has @.icons;
     has Str $.mimeType;
     has MCP::Types::Annotations $.annotations;
     has &.reader is required;
@@ -184,6 +204,8 @@ class RegisteredResourceTemplate is export {
             uriTemplate => $!uri-template,
             name => $!name,
             description => $!description,
+            title => $!title,
+            icons => @!icons,
             mimeType => $!mimeType,
             annotations => $!annotations,
         )
@@ -282,6 +304,8 @@ class ResourceTemplateBuilder is export {
     has Str $!uri-template;
     has Str $!name;
     has Str $!description;
+    has Str $!title;
+    has @!icons;
     has Str $!mimeType;
     has MCP::Types::Annotations $!annotations;
     has &!reader;
@@ -298,6 +322,16 @@ class ResourceTemplateBuilder is export {
 
     method description(Str $desc --> ResourceTemplateBuilder) {
         $!description = $desc;
+        self
+    }
+
+    method title(Str $t --> ResourceTemplateBuilder) {
+        $!title = $t;
+        self
+    }
+
+    method icon(Str $src, Str :$mimeType, :@sizes --> ResourceTemplateBuilder) {
+        @!icons.push(MCP::Types::IconDefinition.new(:$src, :$mimeType, :@sizes));
         self
     }
 
@@ -325,6 +359,8 @@ class ResourceTemplateBuilder is export {
             uri-template => $!uri-template,
             name => $!name,
             description => $!description,
+            title => $!title,
+            icons => @!icons,
             mimeType => $!mimeType,
             annotations => $!annotations,
             reader => &!reader,

--- a/lib/MCP/Server/Tool.rakumod
+++ b/lib/MCP/Server/Tool.rakumod
@@ -27,6 +27,8 @@ our sub validate-tool-name(Str $name) is export {
 class RegisteredTool is export {
     has Str $.name is required;
     has Str $.description;
+    has Str $.title;
+    has @.icons;
     has Hash $.inputSchema;
     has Hash $.outputSchema;
     has MCP::Types::ToolAnnotations $.annotations;
@@ -38,6 +40,8 @@ class RegisteredTool is export {
         MCP::Types::Tool.new(
             name => $!name,
             description => $!description,
+            title => $!title,
+            icons => @!icons,
             inputSchema => $!inputSchema,
             outputSchema => $!outputSchema,
             annotations => $!annotations,
@@ -122,6 +126,8 @@ class RegisteredTool is export {
 class ToolBuilder is export {
     has Str $!name;
     has Str $!description;
+    has Str $!title;
+    has @!icons;
     has Hash $!inputSchema = { type => 'object', properties => {}, required => [] };
     has Hash $!outputSchema;
     has MCP::Types::ToolAnnotations $!annotations;
@@ -135,6 +141,16 @@ class ToolBuilder is export {
 
     method description(Str $desc --> ToolBuilder) {
         $!description = $desc;
+        self
+    }
+
+    method title(Str $t --> ToolBuilder) {
+        $!title = $t;
+        self
+    }
+
+    method icon(Str $src, Str :$mimeType, :@sizes --> ToolBuilder) {
+        @!icons.push(MCP::Types::IconDefinition.new(:$src, :$mimeType, :@sizes));
         self
     }
 
@@ -251,6 +267,8 @@ class ToolBuilder is export {
         RegisteredTool.new(
             name => $!name,
             description => $!description,
+            title => $!title,
+            icons => @!icons,
             inputSchema => $!inputSchema,
             outputSchema => $!outputSchema,
             annotations => $!annotations,

--- a/t/01-types.rakutest
+++ b/t/01-types.rakutest
@@ -16,7 +16,7 @@ use lib 'lib';
 
 use MCP::Types;
 
-plan 41;
+plan 45;
 
 # Test Implementation
 subtest 'Implementation', {
@@ -626,6 +626,107 @@ subtest 'ServerCapabilities from-hash', {
     my $restored = ServerCapabilities.from-hash(%h);
     ok $restored.tools.defined, 'from-hash restores tools';
     ok $restored.tasks.defined, 'from-hash restores tasks';
+};
+
+# Test IconDefinition
+subtest 'IconDefinition', {
+    my $icon = IconDefinition.new(
+        src => 'https://example.com/icon.png',
+        mimeType => 'image/png',
+        sizes => ['48x48', '96x96'],
+    );
+    is $icon.src, 'https://example.com/icon.png', 'src correct';
+    is $icon.mimeType, 'image/png', 'mimeType correct';
+    is $icon.sizes.elems, 2, 'sizes count';
+
+    my %h = $icon.Hash;
+    is %h<src>, 'https://example.com/icon.png', 'Hash src';
+    is %h<mimeType>, 'image/png', 'Hash mimeType';
+    is %h<sizes>.elems, 2, 'Hash sizes';
+
+    # from-hash round-trip
+    my $restored = IconDefinition.from-hash(%h);
+    is $restored.src, $icon.src, 'from-hash src';
+    is $restored.mimeType, $icon.mimeType, 'from-hash mimeType';
+    is $restored.sizes.elems, 2, 'from-hash sizes';
+
+    # Minimal (src only)
+    my $min = IconDefinition.new(src => 'data:image/svg+xml,...');
+    my %h2 = $min.Hash;
+    is %h2<src>, 'data:image/svg+xml,...', 'minimal src';
+    nok %h2<mimeType>:exists, 'no mimeType when not set';
+    nok %h2<sizes>:exists, 'no sizes when empty';
+};
+
+# Test icons and title on Tool
+subtest 'Tool with icons and title', {
+    my $icon = IconDefinition.new(src => 'https://example.com/tool.png', mimeType => 'image/png');
+    my $tool = Tool.new(
+        name => 'icon_tool',
+        title => 'Icon Tool',
+        icons => [$icon],
+    );
+    is $tool.title, 'Icon Tool', 'title correct';
+    is $tool.icons.elems, 1, 'icons count';
+
+    my %h = $tool.Hash;
+    is %h<title>, 'Icon Tool', 'Hash title';
+    is %h<icons>[0]<src>, 'https://example.com/tool.png', 'Hash icon src';
+
+    my $restored = Tool.from-hash(%h);
+    is $restored.title, 'Icon Tool', 'from-hash title';
+    is $restored.icons.elems, 1, 'from-hash icons';
+    is $restored.icons[0].src, 'https://example.com/tool.png', 'from-hash icon src';
+
+    # Without title/icons
+    my $plain = Tool.new(name => 'plain');
+    my %h2 = $plain.Hash;
+    nok %h2<title>:exists, 'no title when not set';
+    nok %h2<icons>:exists, 'no icons when empty';
+};
+
+# Test icons and title on Resource and Prompt
+subtest 'Resource and Prompt with icons and title', {
+    my $icon = IconDefinition.new(src => 'https://example.com/res.png');
+    my $res = Resource.new(uri => 'file:///x', name => 'X', title => 'X Resource', icons => [$icon]);
+    is $res.title, 'X Resource', 'resource title';
+    my %rh = $res.Hash;
+    is %rh<title>, 'X Resource', 'resource Hash title';
+    is %rh<icons>[0]<src>, 'https://example.com/res.png', 'resource Hash icon';
+
+    my $res2 = Resource.from-hash(%rh);
+    is $res2.title, 'X Resource', 'resource from-hash title';
+    is $res2.icons[0].src, 'https://example.com/res.png', 'resource from-hash icon';
+
+    my $prompt = Prompt.new(name => 'p', title => 'Prompt Title', icons => [$icon]);
+    is $prompt.title, 'Prompt Title', 'prompt title';
+    my %ph = $prompt.Hash;
+    is %ph<title>, 'Prompt Title', 'prompt Hash title';
+
+    my $prompt2 = Prompt.from-hash(%ph);
+    is $prompt2.title, 'Prompt Title', 'prompt from-hash title';
+};
+
+# Test icons and title on Implementation
+subtest 'Implementation with icons and title', {
+    my $icon = IconDefinition.new(src => 'https://example.com/server.png', mimeType => 'image/png');
+    my $impl = Implementation.new(name => 'srv', version => '1.0', title => 'My Server', icons => [$icon]);
+    is $impl.title, 'My Server', 'title correct';
+    is $impl.icons[0].src, 'https://example.com/server.png', 'icon src';
+
+    my %h = $impl.Hash;
+    is %h<title>, 'My Server', 'Hash title';
+    is %h<icons>[0]<src>, 'https://example.com/server.png', 'Hash icon';
+
+    my $restored = Implementation.from-hash(%h);
+    is $restored.title, 'My Server', 'from-hash title';
+    is $restored.icons[0].src, 'https://example.com/server.png', 'from-hash icon';
+
+    # Without title/icons
+    my $plain = Implementation.new(name => 'x', version => '0.1');
+    my %h2 = $plain.Hash;
+    nok %h2<title>:exists, 'no title';
+    nok %h2<icons>:exists, 'no icons';
 };
 
 done-testing;

--- a/t/03-builders.rakutest
+++ b/t/03-builders.rakutest
@@ -283,6 +283,67 @@ subtest 'Prompt builder and normalization', {
     dies-ok { prompt().name('p').build }, 'prompt requires generator';
 };
 
+subtest 'Builder title and icon methods', {
+    # Tool builder
+    my $t = tool()
+        .name('icon-tool')
+        .title('Icon Tool')
+        .icon('https://example.com/icon.png', mimeType => 'image/png', sizes => ['48x48'])
+        .icon('https://example.com/icon2.svg')
+        .handler(-> { 'ok' })
+        .build;
+
+    my $tool-def = $t.to-tool;
+    is $tool-def.title, 'Icon Tool', 'tool title set';
+    is $tool-def.icons.elems, 2, 'tool has 2 icons';
+    is $tool-def.icons[0].src, 'https://example.com/icon.png', 'tool icon src';
+    is $tool-def.icons[0].mimeType, 'image/png', 'tool icon mimeType';
+    is $tool-def.icons[1].src, 'https://example.com/icon2.svg', 'tool second icon';
+
+    my %th = $tool-def.Hash;
+    is %th<title>, 'Icon Tool', 'tool Hash title';
+    is %th<icons>.elems, 2, 'tool Hash icons';
+
+    # Resource builder
+    my $r = resource()
+        .uri('info://x')
+        .name('X')
+        .title('X Resource')
+        .icon('https://example.com/res.png')
+        .reader({ 'data' })
+        .build;
+
+    my $res-def = $r.to-resource;
+    is $res-def.title, 'X Resource', 'resource title set';
+    is $res-def.icons.elems, 1, 'resource has 1 icon';
+
+    # Resource template builder
+    my $rt = resource-template()
+        .uri-template('file:///{path}')
+        .name('Files')
+        .title('File Browser')
+        .icon('https://example.com/file.png')
+        .reader(-> %p { 'content' })
+        .build;
+
+    my $rt-def = $rt.to-resource-template;
+    is $rt-def.title, 'File Browser', 'resource template title set';
+    is $rt-def.icons.elems, 1, 'resource template has 1 icon';
+
+    # Prompt builder
+    my $p = prompt()
+        .name('icon-prompt')
+        .title('Icon Prompt')
+        .icon('https://example.com/prompt.png', mimeType => 'image/png')
+        .generator(-> { 'hello' })
+        .build;
+
+    my $prompt-def = $p.to-prompt;
+    is $prompt-def.title, 'Icon Prompt', 'prompt title set';
+    is $prompt-def.icons.elems, 1, 'prompt has 1 icon';
+    is $prompt-def.icons[0].mimeType, 'image/png', 'prompt icon mimeType';
+};
+
 subtest 'Tool name validation', {
     # Valid names
     lives-ok { tool().name('my-tool').handler(-> { 'ok' }).build }, 'valid: my-tool';


### PR DESCRIPTION
Add `icons` array and `title` field to Tool, Resource, Prompt, ResourceTemplate,
and Implementation per SEP-973. Includes IconDefinition type, builder methods
(.title(), .icon()), Hash/from-hash round-trip support, and full test coverage.