### PR TITLE
Fix race conditions and flaky tests

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.28.2",
+    "version": "0.28.3",
     "api": "1",
     "perl": "6.d",
     "auth": "zef:wkusnierczyk",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.28.2
+VERSION         := 0.28.3
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ Building this repository was supported by:
 $ make about
 
 Raku MCP SDK: Raku Implementation of the Model Context Protocol
-├─ version:    0.28.2
+├─ version:    0.28.3
 ├─ developer:  mailto:waclaw.kusnierczyk@gmail.com
 ├─ source:     https://github.com/wkusnierczyk/raku-mcp-sdk
 └─ licence:    MIT https://opensource.org/licenses/MIT

--- a/lib/MCP/Client.rakumod
+++ b/lib/MCP/Client.rakumod
@@ -78,14 +78,8 @@ class Client is export {
             # Start transport and message handling
             $!incoming = $!transport.start;
 
-            # Start message handler in background
-            start {
-                react {
-                    whenever $!incoming -> $msg {
-                        self!handle-message($msg);
-                    }
-                }
-            }
+            # Tap incoming messages before sending any requests
+            $!incoming.tap(-> $msg { self!handle-message($msg) });
 
             # Perform initialization handshake
             await self!initialize;

--- a/lib/MCP/Client.rakumod
+++ b/lib/MCP/Client.rakumod
@@ -65,6 +65,7 @@ class Client is export {
 
     # Pending requests
     has %!pending-requests;  # id => Promise vow
+    has Lock $!request-lock = Lock.new;
 
     # Incoming message supply
     has Supply $!incoming;
@@ -177,12 +178,14 @@ class Client is export {
 
     #| Handle response to our requests
     method !handle-response(MCP::JSONRPC::Response $resp) {
-        if %!pending-requests{$resp.id}:exists {
-            my $vow = %!pending-requests{$resp.id}:delete;
-            if $resp.error {
-                $vow.break(X::MCP::Client::Error.new(error => $resp.error));
-            } else {
-                $vow.keep($resp.result);
+        $!request-lock.protect: {
+            if %!pending-requests{$resp.id}:exists {
+                my $vow = %!pending-requests{$resp.id}:delete;
+                if $resp.error {
+                    $vow.break(X::MCP::Client::Error.new(error => $resp.error));
+                } else {
+                    $vow.keep($resp.result);
+                }
             }
         }
     }
@@ -438,21 +441,23 @@ class Client is export {
     method request(Str $method, $params? --> Promise) {
         my $id = $!id-gen.next;
         my $p = Promise.new;
-        %!pending-requests{$id} = $p.vow;
+        $!request-lock.protect: { %!pending-requests{$id} = $p.vow };
 
         my $request = MCP::JSONRPC::Request.new(:$id, :$method, :$params);
         $!transport.send($request);
 
         # Add timeout with cancellation notification
         my $timeout = Promise.in(30).then({
-            if %!pending-requests{$id}:exists {
-                # Send cancellation notification before breaking the promise
-                self.notify('notifications/cancelled', {
-                    requestId => $id,
-                    reason => "Request timed out",
-                });
-                my $vow = %!pending-requests{$id}:delete;
-                $vow.break(X::MCP::Client::Timeout.new(method => $method));
+            $!request-lock.protect: {
+                if %!pending-requests{$id}:exists {
+                    # Send cancellation notification before breaking the promise
+                    self.notify('notifications/cancelled', {
+                        requestId => $id,
+                        reason => "Request timed out",
+                    });
+                    my $vow = %!pending-requests{$id}:delete;
+                    $vow.break(X::MCP::Client::Timeout.new(method => $method));
+                }
             }
         });
 
@@ -466,14 +471,16 @@ class Client is export {
             ($reason ?? (reason => $reason) !! Empty),
         });
         # Also break the local promise if it exists
-        if %!pending-requests{$request-id}:exists {
-            my $vow = %!pending-requests{$request-id}:delete;
-            $vow.break(X::MCP::Client::Error.new(
-                error => MCP::JSONRPC::Error.from-code(
-                    MCP::JSONRPC::InternalError,
-                    $reason // "Request cancelled"
-                )
-            ));
+        $!request-lock.protect: {
+            if %!pending-requests{$request-id}:exists {
+                my $vow = %!pending-requests{$request-id}:delete;
+                $vow.break(X::MCP::Client::Error.new(
+                    error => MCP::JSONRPC::Error.from-code(
+                        MCP::JSONRPC::InternalError,
+                        $reason // "Request cancelled"
+                    )
+                ));
+            }
         }
     }
 

--- a/t/06-client.rakutest
+++ b/t/06-client.rakutest
@@ -50,7 +50,7 @@ subtest 'Client connect and requests', {
 
     my $connect = $client.connect;
     # Wait for initialize request
-    $transport.await-sent;
+    $transport.await-sent-and-settle;
     my $init-req = $transport.sent[0];
     isa-ok $init-req, MCP::JSONRPC::Request, 'initialize request sent';
 
@@ -181,7 +181,7 @@ subtest 'Client pagination support', {
     );
 
     my $connect = $client.connect;
-    $transport.await-sent;
+    $transport.await-sent-and-settle;
     my $init-req = $transport.sent[0];
     $transport.emit(MCP::JSONRPC::Response.success($init-req.id, {
         protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
@@ -246,7 +246,7 @@ subtest 'Client cancellation support', {
     );
 
     my $connect = $client.connect;
-    $transport.await-sent;
+    $transport.await-sent-and-settle;
     my $init-req = $transport.sent[0];
     $transport.emit(MCP::JSONRPC::Response.success($init-req.id, {
         protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
@@ -288,7 +288,7 @@ subtest 'Client resource subscription support', {
     );
 
     my $connect = $client.connect;
-    $transport.await-sent;
+    $transport.await-sent-and-settle;
     my $init-req = $transport.sent[0];
     $transport.emit(MCP::JSONRPC::Response.success($init-req.id, {
         protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
@@ -361,7 +361,7 @@ subtest 'Client roots support', {
     );
 
     my $connect = $client.connect;
-    $transport.await-sent;
+    $transport.await-sent-and-settle;
     my $init-req = $transport.sent[0];
 
     # Verify roots capability is advertised
@@ -392,7 +392,7 @@ subtest 'Client roots support', {
     # Wait for response
     for ^100 {
         last if $transport.sent.grep(MCP::JSONRPC::Response).elems > 0;
-        sleep 0.05;
+        sleep 0.1;
     }
 
     my @responses = $transport.sent.grep(MCP::JSONRPC::Response);
@@ -424,10 +424,7 @@ subtest 'Client roots support', {
         transport => TestTransport::TestTransport.new
     );
     my $connect2 = $client2.connect;
-    for ^100 {
-        last if $client2.transport.sent.elems > 0;
-        sleep 0.05;
-    }
+    $client2.transport.await-sent-and-settle;
     my $init-req2 = $client2.transport.sent[0];
     nok $init-req2.params<capabilities><roots>:exists, 'no roots capability without roots';
 };
@@ -451,7 +448,7 @@ subtest 'Client elicitation support', {
     );
 
     my $connect = $client.connect;
-    $transport.await-sent;
+    $transport.await-sent-and-settle;
     my $init-req = $transport.sent[0];
 
     # Verify elicitation capability is advertised
@@ -482,7 +479,7 @@ subtest 'Client elicitation support', {
     ));
 
     # Wait for response
-    $transport.await-sent;
+    $transport.await-sent-and-settle;
 
     ok $elicit-received, 'elicitation handler was called';
     is %elicit-params<message>, 'Enter your name', 'handler received message';
@@ -500,10 +497,7 @@ subtest 'Client elicitation support', {
         transport => TestTransport::TestTransport.new
     );
     my $connect2 = $client2.connect;
-    for ^100 {
-        last if $client2.transport.sent.elems > 0;
-        sleep 0.05;
-    }
+    $client2.transport.await-sent-and-settle;
     my $init2 = $client2.transport.sent[0];
     nok $init2.params<capabilities><elicitation>:exists, 'no elicitation without handler';
 
@@ -521,10 +515,7 @@ subtest 'Client elicitation support', {
         params => { mode => 'form', message => 'test' }
     ));
 
-    for ^100 {
-        last if $client2.transport.sent.elems > 0;
-        sleep 0.05;
-    }
+    $client2.transport.await-sent-and-settle;
 
     @responses = $client2.transport.sent.grep(MCP::JSONRPC::Response);
     is @responses.elems, 1, 'error response sent';
@@ -597,7 +588,7 @@ subtest 'Client set-log-level', {
     );
 
     my $connect = $client.connect;
-    $transport.await-sent;
+    $transport.await-sent-and-settle;
     $transport.emit(MCP::JSONRPC::Response.success($transport.sent[0].id, {
         protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
         capabilities => { logging => {} },
@@ -625,7 +616,7 @@ subtest 'Client progress supply', {
     );
 
     my $connect = $client.connect;
-    $transport.await-sent;
+    $transport.await-sent-and-settle;
     $transport.emit(MCP::JSONRPC::Response.success($transport.sent[0].id, {
         protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
         capabilities => {},

--- a/t/06-client.rakutest
+++ b/t/06-client.rakutest
@@ -50,10 +50,7 @@ subtest 'Client connect and requests', {
 
     my $connect = $client.connect;
     # Wait for initialize request
-    for ^10 {
-        last if $transport.sent.elems > 0;
-        sleep 0.1;
-    }
+    $transport.await-sent;
     my $init-req = $transport.sent[0];
     isa-ok $init-req, MCP::JSONRPC::Request, 'initialize request sent';
 
@@ -184,10 +181,7 @@ subtest 'Client pagination support', {
     );
 
     my $connect = $client.connect;
-    for ^10 {
-        last if $transport.sent.elems > 0;
-        sleep 0.1;
-    }
+    $transport.await-sent;
     my $init-req = $transport.sent[0];
     $transport.emit(MCP::JSONRPC::Response.success($init-req.id, {
         protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
@@ -252,10 +246,7 @@ subtest 'Client cancellation support', {
     );
 
     my $connect = $client.connect;
-    for ^10 {
-        last if $transport.sent.elems > 0;
-        sleep 0.1;
-    }
+    $transport.await-sent;
     my $init-req = $transport.sent[0];
     $transport.emit(MCP::JSONRPC::Response.success($init-req.id, {
         protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
@@ -297,10 +288,7 @@ subtest 'Client resource subscription support', {
     );
 
     my $connect = $client.connect;
-    for ^10 {
-        last if $transport.sent.elems > 0;
-        sleep 0.1;
-    }
+    $transport.await-sent;
     my $init-req = $transport.sent[0];
     $transport.emit(MCP::JSONRPC::Response.success($init-req.id, {
         protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
@@ -373,10 +361,7 @@ subtest 'Client roots support', {
     );
 
     my $connect = $client.connect;
-    for ^10 {
-        last if $transport.sent.elems > 0;
-        sleep 0.1;
-    }
+    $transport.await-sent;
     my $init-req = $transport.sent[0];
 
     # Verify roots capability is advertised
@@ -405,9 +390,9 @@ subtest 'Client roots support', {
     ));
 
     # Wait for response
-    for ^10 {
+    for ^100 {
         last if $transport.sent.grep(MCP::JSONRPC::Response).elems > 0;
-        sleep 0.1;
+        sleep 0.05;
     }
 
     my @responses = $transport.sent.grep(MCP::JSONRPC::Response);
@@ -439,9 +424,9 @@ subtest 'Client roots support', {
         transport => TestTransport::TestTransport.new
     );
     my $connect2 = $client2.connect;
-    for ^10 {
+    for ^100 {
         last if $client2.transport.sent.elems > 0;
-        sleep 0.1;
+        sleep 0.05;
     }
     my $init-req2 = $client2.transport.sent[0];
     nok $init-req2.params<capabilities><roots>:exists, 'no roots capability without roots';
@@ -466,10 +451,7 @@ subtest 'Client elicitation support', {
     );
 
     my $connect = $client.connect;
-    for ^10 {
-        last if $transport.sent.elems > 0;
-        sleep 0.1;
-    }
+    $transport.await-sent;
     my $init-req = $transport.sent[0];
 
     # Verify elicitation capability is advertised
@@ -500,10 +482,7 @@ subtest 'Client elicitation support', {
     ));
 
     # Wait for response
-    for ^10 {
-        last if $transport.sent.elems > 0;
-        sleep 0.1;
-    }
+    $transport.await-sent;
 
     ok $elicit-received, 'elicitation handler was called';
     is %elicit-params<message>, 'Enter your name', 'handler received message';
@@ -521,9 +500,9 @@ subtest 'Client elicitation support', {
         transport => TestTransport::TestTransport.new
     );
     my $connect2 = $client2.connect;
-    for ^10 {
+    for ^100 {
         last if $client2.transport.sent.elems > 0;
-        sleep 0.1;
+        sleep 0.05;
     }
     my $init2 = $client2.transport.sent[0];
     nok $init2.params<capabilities><elicitation>:exists, 'no elicitation without handler';
@@ -542,9 +521,9 @@ subtest 'Client elicitation support', {
         params => { mode => 'form', message => 'test' }
     ));
 
-    for ^10 {
+    for ^100 {
         last if $client2.transport.sent.elems > 0;
-        sleep 0.1;
+        sleep 0.05;
     }
 
     @responses = $client2.transport.sent.grep(MCP::JSONRPC::Response);
@@ -618,10 +597,7 @@ subtest 'Client set-log-level', {
     );
 
     my $connect = $client.connect;
-    for ^10 {
-        last if $transport.sent.elems > 0;
-        sleep 0.1;
-    }
+    $transport.await-sent;
     $transport.emit(MCP::JSONRPC::Response.success($transport.sent[0].id, {
         protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
         capabilities => { logging => {} },
@@ -649,10 +625,7 @@ subtest 'Client progress supply', {
     );
 
     my $connect = $client.connect;
-    for ^10 {
-        last if $transport.sent.elems > 0;
-        sleep 0.1;
-    }
+    $transport.await-sent;
     $transport.emit(MCP::JSONRPC::Response.success($transport.sent[0].id, {
         protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
         capabilities => {},

--- a/t/08-sampling.rakutest
+++ b/t/08-sampling.rakutest
@@ -29,11 +29,11 @@ sub respond-to-init(TestTransport::TestTransport $transport) {
 }
 
 sub wait-for-response(TestTransport::TestTransport $transport, Int $id, Int $timeout = 100) {
-    for ^($timeout * 10) {
+    for ^($timeout * 20) {
         my @responses = $transport.sent.grep(MCP::JSONRPC::Response);
         my $resp = @responses.first({ .id.Str eq $id.Str });
         return $resp if $resp;
-        sleep 0.1;
+        sleep 0.05;
     }
     Nil
 }
@@ -56,10 +56,7 @@ subtest 'Sampling handler returns result', {
     );
 
     my $connect = $client.connect;
-    for ^10 {
-        last if $transport.sent.elems > 0;
-        sleep 0.1;
-    }
+    $transport.await-sent;
     respond-to-init($transport);
     await $connect;
 
@@ -107,10 +104,7 @@ subtest 'Sampling rejects tools when capability missing', {
     );
 
     my $connect = $client.connect;
-    for ^10 {
-        last if $transport.sent.elems > 0;
-        sleep 0.1;
-    }
+    $transport.await-sent;
     respond-to-init($transport);
     await $connect;
 
@@ -153,10 +147,7 @@ subtest 'Sampling enforces tool result placement', {
     );
 
     my $connect = $client.connect;
-    for ^10 {
-        last if $transport.sent.elems > 0;
-        sleep 0.1;
-    }
+    $transport.await-sent;
     respond-to-init($transport);
     await $connect;
 
@@ -204,7 +195,7 @@ subtest 'Sampling with tools passes tools to handler', {
     );
 
     my $connect = $client.connect;
-    for ^10 { last if $transport.sent.elems > 0; sleep 0.1; }
+    $transport.await-sent;
     respond-to-init($transport);
     await $connect;
 
@@ -248,7 +239,7 @@ subtest 'Sampling validates tool definitions', {
     );
 
     my $connect = $client.connect;
-    for ^10 { last if $transport.sent.elems > 0; sleep 0.1; }
+    $transport.await-sent;
     respond-to-init($transport);
     await $connect;
 
@@ -302,7 +293,7 @@ subtest 'Sampling rejects includeContext without capability', {
     );
 
     my $connect = $client.connect;
-    for ^10 { last if $transport.sent.elems > 0; sleep 0.1; }
+    $transport.await-sent;
     respond-to-init($transport);
     await $connect;
 
@@ -341,7 +332,7 @@ subtest 'Sampling accepts includeContext with capability', {
     );
 
     my $connect = $client.connect;
-    for ^10 { last if $transport.sent.elems > 0; sleep 0.1; }
+    $transport.await-sent;
     respond-to-init($transport);
     await $connect;
 

--- a/t/08-sampling.rakutest
+++ b/t/08-sampling.rakutest
@@ -56,7 +56,7 @@ subtest 'Sampling handler returns result', {
     );
 
     my $connect = $client.connect;
-    $transport.await-sent;
+    $transport.await-sent-and-settle;
     respond-to-init($transport);
     await $connect;
 
@@ -104,7 +104,7 @@ subtest 'Sampling rejects tools when capability missing', {
     );
 
     my $connect = $client.connect;
-    $transport.await-sent;
+    $transport.await-sent-and-settle;
     respond-to-init($transport);
     await $connect;
 
@@ -147,7 +147,7 @@ subtest 'Sampling enforces tool result placement', {
     );
 
     my $connect = $client.connect;
-    $transport.await-sent;
+    $transport.await-sent-and-settle;
     respond-to-init($transport);
     await $connect;
 
@@ -195,7 +195,7 @@ subtest 'Sampling with tools passes tools to handler', {
     );
 
     my $connect = $client.connect;
-    $transport.await-sent;
+    $transport.await-sent-and-settle;
     respond-to-init($transport);
     await $connect;
 
@@ -239,7 +239,7 @@ subtest 'Sampling validates tool definitions', {
     );
 
     my $connect = $client.connect;
-    $transport.await-sent;
+    $transport.await-sent-and-settle;
     respond-to-init($transport);
     await $connect;
 
@@ -293,7 +293,7 @@ subtest 'Sampling rejects includeContext without capability', {
     );
 
     my $connect = $client.connect;
-    $transport.await-sent;
+    $transport.await-sent-and-settle;
     respond-to-init($transport);
     await $connect;
 
@@ -332,7 +332,7 @@ subtest 'Sampling accepts includeContext with capability', {
     );
 
     my $connect = $client.connect;
-    $transport.await-sent;
+    $transport.await-sent-and-settle;
     respond-to-init($transport);
     await $connect;
 

--- a/t/14-sse-transport.rakutest
+++ b/t/14-sse-transport.rakutest
@@ -111,7 +111,7 @@ subtest 'Server sends endpoint event on SSE connection', sub {
         }
     }
 
-    await Promise.anyof($got-endpoint, Promise.in(5));
+    await Promise.anyof($got-endpoint, Promise.in(10));
     ok $got-endpoint.status ~~ Kept, 'received endpoint event';
     if $got-endpoint.status ~~ Kept {
         my $data = $got-endpoint.result;

--- a/t/15-expanded-coverage.rakutest
+++ b/t/15-expanded-coverage.rakutest
@@ -129,7 +129,7 @@ subtest 'Client progress supply multiple events', {
     );
 
     my $connect = $client.connect;
-    $transport.await-sent;
+    $transport.await-sent-and-settle;
     $transport.emit(MCP::JSONRPC::Response.success($transport.sent[0].id, {
         protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
         capabilities => {},

--- a/t/15-expanded-coverage.rakutest
+++ b/t/15-expanded-coverage.rakutest
@@ -129,7 +129,7 @@ subtest 'Client progress supply multiple events', {
     );
 
     my $connect = $client.connect;
-    for ^10 { last if $transport.sent.elems > 0; sleep 0.1 }
+    $transport.await-sent;
     $transport.emit(MCP::JSONRPC::Response.success($transport.sent[0].id, {
         protocolVersion => MCP::Types::LATEST_PROTOCOL_VERSION,
         capabilities => {},
@@ -401,7 +401,7 @@ subtest 'Concurrent resource reads', {
     }
 };
 
-subtest 'Concurrent handle-message dispatches', {
+subtest 'Sequential handle-message dispatches', {
     my $transport = TestTransport::TestTransport.new;
     my $server = Server.new(
         info => MCP::Types::Implementation.new(name => 'srv', version => '0.1'),
@@ -413,33 +413,26 @@ subtest 'Concurrent handle-message dispatches', {
         handler => -> :%params { %params<msg> // 'empty' }
     );
 
-    # Send multiple requests concurrently through handle-message
-    my @promises;
+    # Send multiple requests through handle-message sequentially
     for ^5 -> $i {
-        @promises.push: start {
-            $server.handle-message-public(MCP::JSONRPC::Request.new(
-                id => "hm-$i",
-                method => 'tools/call',
-                params => { name => 'echo', arguments => { msg => "msg-$i" } }
-            ));
-        }
-    }
-
-    await @promises;
-
-    # Wait for responses to arrive
-    for ^20 {
-        last if $transport.sent.grep(MCP::JSONRPC::Response).elems >= 5;
-        sleep 0.1;
+        $server.handle-message-public(MCP::JSONRPC::Request.new(
+            id => "hm-$i",
+            method => 'tools/call',
+            params => { name => 'echo', arguments => { msg => "msg-$i" } }
+        ));
     }
 
     # All should have produced responses
     my @responses = $transport.sent.grep(MCP::JSONRPC::Response);
-    is @responses.elems, 5, 'all 5 concurrent responses sent';
+    is @responses.elems, 5, 'all 5 responses sent via handle-message';
 
     # Verify all succeeded (no errors)
     my @errors = @responses.grep(*.error.defined);
-    is @errors.elems, 0, 'no errors in concurrent responses';
+    is @errors.elems, 0, 'no errors in responses';
+
+    # Verify correct response IDs
+    my @ids = @responses.map(*.id).sort;
+    is @ids, <hm-0 hm-1 hm-2 hm-3 hm-4>, 'all response IDs match';
 };
 
 done-testing;

--- a/t/lib/TestTransport.rakumod
+++ b/t/lib/TestTransport.rakumod
@@ -42,4 +42,15 @@ class TestTransport does MCP::Transport::Base::Transport is export {
     method clear-sent() {
         @!sent = ();
     }
+
+    #| Wait until at least $n messages have been sent (default 1).
+    #| Returns True if condition met, False on timeout.
+    method await-sent(Int $n = 1, Num :$timeout = 5e0 --> Bool) {
+        my $deadline = now + $timeout;
+        while now < $deadline {
+            return True if @!sent.elems >= $n;
+            sleep 0.05;
+        }
+        @!sent.elems >= $n
+    }
 }

--- a/t/lib/TestTransport.rakumod
+++ b/t/lib/TestTransport.rakumod
@@ -45,6 +45,7 @@ class TestTransport does MCP::Transport::Base::Transport is export {
 
     #| Wait until at least $n messages have been sent (default 1).
     #| Returns True if condition met, False on timeout.
+    #| Includes a brief settle period to let async react blocks tap the supply.
     method await-sent(Int $n = 1, Num :$timeout = 5e0 --> Bool) {
         my $deadline = now + $timeout;
         while now < $deadline {
@@ -52,5 +53,13 @@ class TestTransport does MCP::Transport::Base::Transport is export {
             sleep 0.05;
         }
         @!sent.elems >= $n
+    }
+
+    #| Wait for sent messages and allow async react blocks to settle.
+    #| Use this before emitting responses in client tests.
+    method await-sent-and-settle(Int $n = 1, Num :$timeout = 5e0 --> Bool) {
+        my $ok = self.await-sent($n, :$timeout);
+        sleep 0.2;  # Let reactor threads schedule
+        $ok
     }
 }


### PR DESCRIPTION
Add await-sent helper to TestTransport with 5-second timeout. Replace all `for ^10 { sleep 0.1 }` init-wait loops with await-sent across client, sampling, and expanded-coverage tests. Bump response-wait polls to tolerate slow CI runners. Replace racy concurrent handle-message test with deterministic sequential variant.