### PR TITLE
Bump Rakudo from 2024.01 to 2024.12 in CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 env:
   # Raku version to use
-  RAKU_VERSION: '2024.01'
+  RAKU_VERSION: '2024.12'
 
 jobs:
   # ----------------------------------------------------------------------------
@@ -70,11 +70,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        raku-version: ['2024.01', 'latest']
+        raku-version: ['2024.12', 'latest']
         exclude:
           # Exclude some combinations to reduce CI time
           - os: windows-latest
-            raku-version: '2024.01'
+            raku-version: '2024.12'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+-*'  # Pre-release tags like v1.0.0-beta.1
 
 env:
-  RAKU_VERSION: '2024.01'
+  RAKU_VERSION: '2024.12'
 
 jobs:
   # ----------------------------------------------------------------------------
@@ -83,9 +83,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            raku-version: '2024.01'
+            raku-version: '2024.12'
           - os: macos-latest
-            raku-version: '2024.01'
+            raku-version: '2024.12'
           - os: windows-latest
             raku-version: 'latest'
 

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.28.3",
+    "version": "0.28.4",
     "api": "1",
     "perl": "6.d",
     "auth": "zef:wkusnierczyk",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.28.3
+VERSION         := 0.28.4
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ Building this repository was supported by:
 $ make about
 
 Raku MCP SDK: Raku Implementation of the Model Context Protocol
-├─ version:    0.28.3
+├─ version:    0.28.4
 ├─ developer:  mailto:waclaw.kusnierczyk@gmail.com
 ├─ source:     https://github.com/wkusnierczyk/raku-mcp-sdk
 └─ licence:    MIT https://opensource.org/licenses/MIT


### PR DESCRIPTION
Fixes fez publish failure caused by Fez::Web incompatibility with Rakudo 2024.01.