### PR TITLE
Fix release workflow, harden SSE test, and update README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,8 +344,10 @@ jobs:
             raku-${{ runner.os }}-${{ env.RAKU_VERSION }}-
             raku-${{ runner.os }}-
 
-      - name: Install fez
-        run: zef install fez
+      - name: Install fez and HTTP dependency
+        run: |
+          zef install Cro::HTTP || zef install HTTP::Tiny
+          zef install fez
 
       - name: Configure fez
         env:

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.28.5",
+    "version": "0.28.6",
     "api": "1",
     "perl": "6.d",
     "auth": "zef:wkusnierczyk",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.28.5
+VERSION         := 0.28.6
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ See the [Gap Analysis](GAP_ANALYSIS.md) for details.
   - [Makefile targets](#makefile-targets)
   - [Environment variables](#environment-variables)
   - [Coverage prerequisites](#coverage-prerequisites)
+  - [CI pipeline](#ci-pipeline)
 - [Project structure](#project-structure)
 - [Contributing](#contributing)
 - [License](#license)
@@ -502,6 +503,24 @@ Then run:
 make coverage
 # report: coverage-report/report.html
 ```
+
+### CI pipeline
+
+The project runs automated checks on every push and pull request via GitHub Actions.
+
+**CI workflow** (`ci.yml`):
+
+1. **Lint** — validates META6.json, checks syntax, and scans formatting.
+2. **Test** — runs the full test suite across a matrix of 3 OSes (Ubuntu, macOS, Windows) and 2 Raku versions (2024.12, latest). Windows is tested on `latest` only.
+3. **Coverage** — runs after tests pass on Ubuntu, generates a coverage report with [RaCoCo](https://github.com/atroxaper/raku-RaCoCo), and fails if coverage drops below 70%.
+
+**Release workflow** (`release.yml`), triggered on version tags (`v*.*.*`):
+
+1. **Validate** — checks the tag matches `META6.json` version.
+2. **Test** — runs the full matrix (same as CI).
+3. **Build** — creates a distribution archive.
+4. **Release** — creates a GitHub release (draft, upload assets, publish).
+5. **Publish** — uploads to the [Zef ecosystem](https://raku.land/) via `fez`.
 
 ## Project structure
 

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ Building this repository was supported by:
 $ make about
 
 Raku MCP SDK: Raku Implementation of the Model Context Protocol
-├─ version:    0.28.5
+├─ version:    0.28.6
 ├─ developer:  mailto:waclaw.kusnierczyk@gmail.com
 ├─ source:     https://github.com/wkusnierczyk/raku-mcp-sdk
 └─ licence:    MIT https://opensource.org/licenses/MIT

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## Status
 
 Raku MCP SDK provides comprehensive coverage of the [MCP specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25).  
-See the [Gap Analysis](GAP_ANALYSIS.md) for details.
+See the [Gap Analysis](https://github.com/wkusnierczyk/raku-mcp-sdk/blob/main/GAP_ANALYSIS.md) for details.
 
 ### Implementation progress
 
@@ -566,7 +566,7 @@ Contributions are welcome. You can:
 
 ## License
 
-MIT License - see the [LICENSE](LICENSE) file and the [MIT License](https://opensource.org/licenses/MIT) site.
+MIT License - see the [LICENSE](https://github.com/wkusnierczyk/raku-mcp-sdk/blob/main/LICENSE) file and the [MIT License](https://opensource.org/licenses/MIT) site.
 
 ## References
 

--- a/t/14-sse-transport.rakutest
+++ b/t/14-sse-transport.rakutest
@@ -111,7 +111,11 @@ subtest 'Server sends endpoint event on SSE connection', sub {
         }
     }
 
-    await Promise.anyof($got-endpoint, Promise.in(10));
+    my $tries = 0;
+    while $got-endpoint.status ~~ Planned && $tries < 100 {
+        sleep 0.2;
+        $tries++;
+    }
     ok $got-endpoint.status ~~ Kept, 'received endpoint event';
     if $got-endpoint.status ~~ Kept {
         my $data = $got-endpoint.result;


### PR DESCRIPTION
## Summary

- Install `Cro::HTTP` before `fez` in the release workflow to fix `Fez::Web` handler error
- Replace fixed timeout with polling loop in SSE endpoint test for CI reliability
- Add CI pipeline section to README (lint, test matrix, coverage gate, release workflow)
- Use absolute GitHub URLs for GAP_ANALYSIS.md and LICENSE links so they resolve on raku.land

## Test plan

- [ ] Release workflow succeeds with `fez upload` on next tag
- [ ] SSE transport test passes consistently on macOS CI
- [ ] README renders correctly on GitHub and raku.land
