### PR TITLE
Fix SSE endpoint test stream tap scheduling race

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.28.6",
+    "version": "0.28.7",
     "api": "1",
     "perl": "6.d",
     "auth": "zef:wkusnierczyk",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.28.6
+VERSION         := 0.28.7
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk

--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ Building this repository was supported by:
 $ make about
 
 Raku MCP SDK: Raku Implementation of the Model Context Protocol
-├─ version:    0.28.6
+├─ version:    0.28.7
 ├─ developer:  mailto:waclaw.kusnierczyk@gmail.com
 ├─ source:     https://github.com/wkusnierczyk/raku-mcp-sdk
 └─ licence:    MIT https://opensource.org/licenses/MIT

--- a/t/14-sse-transport.rakutest
+++ b/t/14-sse-transport.rakutest
@@ -99,17 +99,12 @@ subtest 'Server sends endpoint event on SSE connection', sub {
 
     my $got-endpoint = Promise.new;
     my $buffer = '';
-    start {
-        react {
-            whenever $resp.body-byte-stream -> $chunk {
-                $buffer ~= $chunk.decode('utf-8');
-                if $buffer.contains("\n\n") {
-                    try $got-endpoint.keep($buffer);
-                    done;
-                }
-            }
+    $resp.body-byte-stream.tap(-> $chunk {
+        $buffer ~= $chunk.decode('utf-8');
+        if $buffer.contains("\n\n") {
+            try $got-endpoint.keep($buffer);
         }
-    }
+    });
 
     my $tries = 0;
     while $got-endpoint.status ~~ Planned && $tries < 100 {


### PR DESCRIPTION
Replace start { react { whenever ... } } with synchronous .tap() to ensure the stream consumer is set up before any data arrives.