### PR TITLE
Add configurable scheme to SSE transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ A security review was conducted on the codebase. No critical vulnerabilities wer
 |---------|----------|-------|
 | PKCE verifier retained in memory after token exchange | Medium | [#109](https://github.com/wkusnierczyk/raku-mcp-sdk/issues/109) |
 | Handler exceptions propagate raw to client | Medium | [#110](https://github.com/wkusnierczyk/raku-mcp-sdk/issues/110) |
-| SSE transport hardcodes HTTP scheme | Medium | [#111](https://github.com/wkusnierczyk/raku-mcp-sdk/issues/111) |
+| ~~SSE transport hardcodes HTTP scheme~~ | ~~Medium~~ | [#111](https://github.com/wkusnierczyk/raku-mcp-sdk/issues/111) ✅ |
 
 **Areas reviewed with no issues found:**
 

--- a/lib/MCP/Transport/SSE.rakumod
+++ b/lib/MCP/Transport/SSE.rakumod
@@ -37,6 +37,7 @@ class X::MCP::Transport::SSE::HTTP is X::MCP::Transport::SSE {
 class SSEServerTransport does MCP::Transport::Base::Transport is export {
     has Str $.host = '127.0.0.1';
     has Int $.port = 8080;
+    has Str $.scheme = 'http';
     has Str $.sse-path = '/sse';
     has Str $.message-path = '/message';
     has @.allowed-origins = [];
@@ -131,7 +132,7 @@ class SSEServerTransport does MCP::Transport::Base::Transport is export {
                 }
 
                 $self!setup-sse-stream();
-                my $post-url = "http://{$self.host}:{$self.port}{$message-path}";
+                my $post-url = "{$self.scheme}://{$self.host}:{$self.port}{$message-path}";
                 my $endpoint-event = "event: endpoint\ndata: $post-url\n\n";
 
                 # Emit endpoint event after Supply is tapped by Cro


### PR DESCRIPTION
Replace hardcoded http:// with a configurable $.scheme attribute (defaults to 'http'). Allows setting scheme => 'https' when TLS is configured.