### PR TITLE
Simplify constructor arguments using colon-pair syntax (#137)

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.32.0",
+    "version": "0.32.1",
     "api": "1",
     "perl": "6.d",
     "auth": "zef:wkusnierczyk",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.32.0
+VERSION         := 0.32.1
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk

--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ Building this repository was supported by:
 $ make about
 
 Raku MCP SDK: Raku Implementation of the Model Context Protocol
-├─ version:    0.32.0
+├─ version:    0.32.1
 ├─ developer:  mailto:waclaw.kusnierczyk@gmail.com
 ├─ source:     https://github.com/wkusnierczyk/raku-mcp-sdk
 └─ licence:    MIT https://opensource.org/licenses/MIT

--- a/lib/MCP/JSONRPC.rakumod
+++ b/lib/MCP/JSONRPC.rakumod
@@ -105,7 +105,7 @@ class Error is export {
 
     #| Serialize the error into a Hash
     method Hash(--> Hash) {
-        my %h = code => $!code, message => $!message;
+        my %h = :$!code, :$!message;
         %h<data> = $_ with $!data;
         %h
     }
@@ -142,7 +142,7 @@ class Request does Message is export {
 
     #| Serialize the request into a Hash
     method Hash(--> Hash) {
-        my %h = jsonrpc => $!jsonrpc, id => $!id, method => $!method;
+        my %h = :$!jsonrpc, :$!id, :$!method;
         %h<params> = $_ with $!params;
         %h
     }
@@ -165,7 +165,7 @@ class Response does Message is export {
 
     #| Serialize the response into a Hash
     method Hash(--> Hash) {
-        my %h = jsonrpc => $!jsonrpc, id => $!id;
+        my %h = :$!jsonrpc, :$!id;
         if $!error.defined {
             %h<error> = $!error.Hash;
         } else {
@@ -206,7 +206,7 @@ class Notification does Message is export {
 
     #| Serialize the notification into a Hash
     method Hash(--> Hash) {
-        my %h = jsonrpc => $!jsonrpc, method => $!method;
+        my %h = :$!jsonrpc, :$!method;
         %h<params> = $_ with $!params;
         %h
     }

--- a/lib/MCP/OAuth/Server.rakumod
+++ b/lib/MCP/OAuth/Server.rakumod
@@ -41,8 +41,8 @@ class OAuthServerHandler is export {
     method resource-metadata(--> Hash) {
         ProtectedResourceMetadata.new(
             resource => $!resource-identifier,
-            authorization-servers => @!authorization-servers,
-            scopes-supported => @!scopes-supported,
+            :@!authorization-servers,
+            :@!scopes-supported,
         ).Hash
     }
 

--- a/lib/MCP/Server/Prompt.rakumod
+++ b/lib/MCP/Server/Prompt.rakumod
@@ -61,11 +61,11 @@ class RegisteredPrompt is export {
     #| Get the Prompt definition for listing
     method to-prompt(--> MCP::Types::Prompt) {
         MCP::Types::Prompt.new(
-            name => $!name,
-            description => $!description,
-            title => $!title,
-            icons => @!icons,
-            arguments => @!arguments,
+            :$!name,
+            :$!description,
+            :$!title,
+            :@!icons,
+            :@!arguments,
         )
     }
 
@@ -186,12 +186,12 @@ class PromptBuilder is export {
         die "Prompt generator is required" unless &!generator;
 
         RegisteredPrompt.new(
-            name => $!name,
-            description => $!description,
-            title => $!title,
-            icons => @!icons,
-            arguments => @!arguments,
-            generator => &!generator,
+            :$!name,
+            :$!description,
+            :$!title,
+            :@!icons,
+            :@!arguments,
+            :&!generator,
         )
     }
 }

--- a/lib/MCP/Server/Resource.rakumod
+++ b/lib/MCP/Server/Resource.rakumod
@@ -83,13 +83,13 @@ class RegisteredResource is export {
     #| Get the Resource definition for listing
     method to-resource(--> MCP::Types::Resource) {
         MCP::Types::Resource.new(
-            uri => $!uri,
-            name => $!name,
-            description => $!description,
-            title => $!title,
-            icons => @!icons,
-            mimeType => $!mimeType,
-            annotations => $!annotations,
+            :$!uri,
+            :$!name,
+            :$!description,
+            :$!title,
+            :@!icons,
+            :$!mimeType,
+            :$!annotations,
         )
     }
 
@@ -214,14 +214,14 @@ class ResourceBuilder is export {
         die "Resource reader is required" unless &!reader;
 
         RegisteredResource.new(
-            uri => $!uri,
-            name => $!name,
-            description => $!description,
-            title => $!title,
-            icons => @!icons,
-            mimeType => $!mimeType,
-            annotations => $!annotations,
-            reader => &!reader,
+            :$!uri,
+            :$!name,
+            :$!description,
+            :$!title,
+            :@!icons,
+            :$!mimeType,
+            :$!annotations,
+            :&!reader,
         )
     }
 }
@@ -254,12 +254,12 @@ class RegisteredResourceTemplate is export {
     method to-resource-template(--> MCP::Types::ResourceTemplate) {
         MCP::Types::ResourceTemplate.new(
             uriTemplate => $!uri-template,
-            name => $!name,
-            description => $!description,
-            title => $!title,
-            icons => @!icons,
-            mimeType => $!mimeType,
-            annotations => $!annotations,
+            :$!name,
+            :$!description,
+            :$!title,
+            :@!icons,
+            :$!mimeType,
+            :$!annotations,
         )
     }
 
@@ -409,13 +409,13 @@ class ResourceTemplateBuilder is export {
 
         RegisteredResourceTemplate.new(
             uri-template => $!uri-template,
-            name => $!name,
-            description => $!description,
-            title => $!title,
-            icons => @!icons,
-            mimeType => $!mimeType,
-            annotations => $!annotations,
-            reader => &!reader,
+            :$!name,
+            :$!description,
+            :$!title,
+            :@!icons,
+            :$!mimeType,
+            :$!annotations,
+            :&!reader,
         )
     }
 }

--- a/lib/MCP/Server/Tool.rakumod
+++ b/lib/MCP/Server/Tool.rakumod
@@ -85,14 +85,14 @@ class RegisteredTool is export {
     #| Get the Tool definition for listing
     method to-tool(--> MCP::Types::Tool) {
         MCP::Types::Tool.new(
-            name => $!name,
-            description => $!description,
-            title => $!title,
-            icons => @!icons,
-            inputSchema => $!inputSchema,
-            outputSchema => $!outputSchema,
-            annotations => $!annotations,
-            execution => $!execution,
+            :$!name,
+            :$!description,
+            :$!title,
+            :@!icons,
+            :$!inputSchema,
+            :$!outputSchema,
+            :$!annotations,
+            :$!execution,
         )
     }
 
@@ -312,15 +312,15 @@ class ToolBuilder is export {
         die "Tool handler is required" unless &!handler;
 
         RegisteredTool.new(
-            name => $!name,
-            description => $!description,
-            title => $!title,
-            icons => @!icons,
-            inputSchema => $!inputSchema,
-            outputSchema => $!outputSchema,
-            annotations => $!annotations,
-            execution => $!execution,
-            handler => &!handler,
+            :$!name,
+            :$!description,
+            :$!title,
+            :@!icons,
+            :$!inputSchema,
+            :$!outputSchema,
+            :$!annotations,
+            :$!execution,
+            :&!handler,
         )
     }
 }

--- a/lib/MCP/Transport/SSE.rakumod
+++ b/lib/MCP/Transport/SSE.rakumod
@@ -74,8 +74,8 @@ class SSEServerTransport does MCP::Transport::Base::Transport is export {
         my $application = self!build-router;
         my $server-class = self!cro-class('Cro::HTTP::Server');
         $!server = $server-class.new(
-            host => $!host,
-            port => $!port,
+            :$!host,
+            :$!port,
             application => $application,
         );
         $!server.start;

--- a/lib/MCP/Transport/StreamableHTTP.rakumod
+++ b/lib/MCP/Transport/StreamableHTTP.rakumod
@@ -154,8 +154,8 @@ class StreamableHTTPServerTransport does MCP::Transport::Base::Transport is expo
         my $application = self!build-router;
         my $server-class = self!cro-class('Cro::HTTP::Server');
         $!server = $server-class.new(
-            host => $!host,
-            port => $!port,
+            :$!host,
+            :$!port,
             application => $application,
         );
         $!server.start;

--- a/lib/MCP/Types.rakumod
+++ b/lib/MCP/Types.rakumod
@@ -121,7 +121,7 @@ class IconDefinition is export {
     has @.sizes;
 
     method Hash(--> Hash) {
-        my %h = src => $!src;
+        my %h = :$!src;
         %h<mimeType> = $_ with $!mimeType;
         %h<sizes> = @!sizes.Array if @!sizes;
         %h
@@ -144,7 +144,7 @@ class Implementation is export {
     has @.icons;
 
     method Hash(--> Hash) {
-        my %h = name => $!name, version => $!version;
+        my %h = :$!name, :$!version;
         %h<title> = $_ with $!title;
         %h<icons> = @!icons.map(*.Hash).Array if @!icons;
         %h
@@ -204,7 +204,7 @@ class TextContent does Content is export {
     method type(--> Str) { 'text' }
 
     method Hash(--> Hash) {
-        my %h = type => 'text', text => $!text;
+        my %h = type => 'text', :$!text;
         %h<annotations> = $!annotations.Hash if $!annotations;
         %h
     }
@@ -226,7 +226,7 @@ class ImageContent does Content is export {
     method type(--> Str) { 'image' }
 
     method Hash(--> Hash) {
-        my %h = type => 'image', data => $!data, mimeType => $!mimeType;
+        my %h = type => 'image', :$!data, :$!mimeType;
         %h<annotations> = $!annotations.Hash if $!annotations;
         %h
     }
@@ -241,7 +241,7 @@ class AudioContent does Content is export {
     method type(--> Str) { 'audio' }
 
     method Hash(--> Hash) {
-        my %h = type => 'audio', data => $!data, mimeType => $!mimeType;
+        my %h = type => 'audio', :$!data, :$!mimeType;
         %h<annotations> = $!annotations.Hash if $!annotations;
         %h
     }
@@ -274,7 +274,7 @@ class ResourceLink does Content is export {
     method type(--> Str) { 'resource_link' }
 
     method Hash(--> Hash) {
-        my %h = type => 'resource_link', name => $!name, uri => $!uri;
+        my %h = type => 'resource_link', :$!name, :$!uri;
         %h<title> = $_ with $!title;
         %h<description> = $_ with $!description;
         %h<mimeType> = $_ with $!mimeType;
@@ -295,9 +295,9 @@ class ToolUseContent does Content is export {
     method Hash(--> Hash) {
         {
             type => 'tool_use',
-            id => $!id,
-            name => $!name,
-            input => $!input
+            :$!id,
+            :$!name,
+            :$!input
         }
     }
 }
@@ -313,7 +313,7 @@ class ToolResultContent does Content is export {
     method type(--> Str) { 'tool_result' }
 
     method Hash(--> Hash) {
-        my %h = type => 'tool_result', toolUseId => $!toolUseId;
+        my %h = type => 'tool_result', :$!toolUseId;
         %h<content> = @!content.map(*.Hash).Array;
         %h<isError> = $!isError if $!isError.defined;
         %h<structuredContent> = $_ with $!structuredContent;
@@ -368,7 +368,7 @@ class Task is export {
     has Int $.pollInterval;
 
     method Hash(--> Hash) {
-        my %h = taskId => $!taskId, status => $!status.value;
+        my %h = :$!taskId, status => $!status.value;
         %h<statusMessage> = $_ with $!statusMessage;
         %h<createdAt> = $_ with $!createdAt;
         %h<lastUpdatedAt> = $_ with $!lastUpdatedAt;
@@ -421,7 +421,7 @@ class Tool is export {
     has TaskExecution $.execution;
 
     method Hash(--> Hash) {
-        my %h = name => $!name;
+        my %h = :$!name;
         %h<description> = $_ with $!description;
         %h<title> = $_ with $!title;
         %h<icons> = @!icons.map(*.Hash).Array if @!icons;
@@ -452,7 +452,7 @@ class CallToolResult is export {
     has $.structuredContent;  # Optional structured output matching outputSchema
 
     method Hash(--> Hash) {
-        my %h = content => @!content.map(*.Hash).Array, isError => $!isError;
+        my %h = content => @!content.map(*.Hash).Array, :$!isError;
         %h<structuredContent> = $_ with $!structuredContent;
         %h
     }
@@ -469,7 +469,7 @@ class Resource is export {
     has Annotations $.annotations;
 
     method Hash(--> Hash) {
-        my %h = uri => $!uri, name => $!name;
+        my %h = :$!uri, :$!name;
         %h<description> = $_ with $!description;
         %h<title> = $_ with $!title;
         %h<icons> = @!icons.map(*.Hash).Array if @!icons;
@@ -499,7 +499,7 @@ class ResourceTemplate is export {
     has Annotations $.annotations;
 
     method Hash(--> Hash) {
-        my %h = uriTemplate => $!uriTemplate, name => $!name;
+        my %h = :$!uriTemplate, :$!name;
         %h<description> = $_ with $!description;
         %h<title> = $_ with $!title;
         %h<icons> = @!icons.map(*.Hash).Array if @!icons;
@@ -526,7 +526,7 @@ class ResourceContents is export {
     has Blob $.blob;
 
     method Hash(--> Hash) {
-        my %h = uri => $!uri;
+        my %h = :$!uri;
         %h<mimeType> = $_ with $!mimeType;
         %h<text> = $_ with $!text;
         %h<blob> = $!blob.decode('latin-1') if $!blob;  # base64 in real impl
@@ -541,7 +541,7 @@ class PromptArgument is export {
     has Bool $.required = False;
 
     method Hash(--> Hash) {
-        my %h = name => $!name;
+        my %h = :$!name;
         %h<description> = $_ with $!description;
         %h<required> = $!required;
         %h
@@ -557,7 +557,7 @@ class Prompt is export {
     has @.arguments;  # Array of PromptArgument
 
     method Hash(--> Hash) {
-        my %h = name => $!name;
+        my %h = :$!name;
         %h<description> = $_ with $!description;
         %h<title> = $_ with $!title;
         %h<icons> = @!icons.map(*.Hash).Array if @!icons;
@@ -582,7 +582,7 @@ class PromptMessage is export {
 
     method Hash(--> Hash) {
         {
-            role => $!role,
+            :$!role,
             content => $!content ~~ Positional
                 ?? $!content.map(*.Hash).Array
                 !! $!content.Hash
@@ -597,7 +597,7 @@ class SamplingMessage is export {
 
     method Hash(--> Hash) {
         {
-            role => $!role,
+            :$!role,
             content => $!content ~~ Positional
                 ?? $!content.map(*.Hash).Array
                 !! $!content.Hash
@@ -609,7 +609,7 @@ class SamplingMessage is export {
 class ModelHint is export {
     has Str $.name is required;
 
-    method Hash(--> Hash) { { name => $!name } }
+    method Hash(--> Hash) { { :$!name } }
 }
 
 #| Model preferences for sampling
@@ -635,7 +635,7 @@ class ToolChoice is export {
     has Str $.name;
 
     method Hash(--> Hash) {
-        my %h = mode => $!mode;
+        my %h = :$!mode;
         %h<name> = $_ with $!name;
         %h
     }
@@ -650,7 +650,7 @@ class CreateMessageResult is export {
     has $.meta;
 
     method Hash(--> Hash) {
-        my %h = model => $!model, role => $!role,
+        my %h = :$!model, :$!role,
             content => $!content ~~ Positional
                 ?? $!content.map(*.Hash).Array
                 !! $!content.Hash;
@@ -730,7 +730,7 @@ class Extension is export {
     has Hash $.settings;
 
     method Hash(--> Hash) {
-        my %h = name => $!name;
+        my %h = :$!name;
         %h<version> = $_ with $!version;
         %h<settings> = $_ with $!settings;
         %h
@@ -785,7 +785,7 @@ class Root is export {
     has Str $.name;
 
     method Hash(--> Hash) {
-        my %h = uri => $!uri;
+        my %h = :$!uri;
         %h<name> = $_ with $!name;
         %h
     }
@@ -902,7 +902,7 @@ class Progress is export {
     has Str $.message;
 
     method Hash(--> Hash) {
-        my %h = progressToken => $!progressToken, progress => $!progress;
+        my %h = :$!progressToken, :$!progress;
         %h<total> = $_ with $!total;
         %h<message> = $_ with $!message;
         %h
@@ -943,7 +943,7 @@ class LogEntry is export {
     has $.data is required;  # Any JSON-serializable data
 
     method Hash(--> Hash) {
-        my %h = level => $!level.value, data => $!data;
+        my %h = level => $!level.value, :$!data;
         %h<logger> = $_ with $!logger;
         %h
     }


### PR DESCRIPTION
Replace verbose `name => $!name` patterns with idiomatic `:$!name` shorthand across all builder classes, Hash methods, and .new() calls.

## Summary

Brief description of the changes.

## Related issues

Closes #

## Checklist

- [ ] Tests pass (`make test`)
- [ ] Lint passes (`make lint`)
- [ ] New tests added for new functionality (if applicable)
- [ ] README or docs updated (if applicable)
