### PR TITLE
Simplify argument checking with try/defined-or chain (#140)

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.32.3",
+    "version": "0.32.4",
     "api": "1",
     "perl": "6.d",
     "auth": "zef:wkusnierczyk",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.32.3
+VERSION         := 0.32.4
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk
@@ -448,13 +448,6 @@ coverage: dependencies-dev build
 	"$$RACOCO_CMD" $(RACOCO_COVERAGE_FLAGS) --html --cache-dir=$(COVERAGE_REPORT) \
 		--exec="$(PROVE) $(PROVE_FLAGS) $(TEST_DIR)"
 	$(call log-success,Coverage report generated: $(COVERAGE_REPORT)/report.html)
-
-.PHONY: benchmark
-# benchmark: Run performance benchmarks
-benchmark: build
-	$(call log-info,Running benchmarks...)
-	$(Q)$(RAKU) -Ilib bench/benchmark.rakutest
-	$(call log-success,Benchmarks complete)
 
 # ------------------------------------------------------------------------------
 # Validation

--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ Building this repository was supported by:
 $ make about
 
 Raku MCP SDK: Raku Implementation of the Model Context Protocol
-├─ version:    0.32.3
+├─ version:    0.32.4
 ├─ developer:  mailto:waclaw.kusnierczyk@gmail.com
 ├─ source:     https://github.com/wkusnierczyk/raku-mcp-sdk
 └─ licence:    MIT https://opensource.org/licenses/MIT

--- a/lib/MCP/Server/Prompt.rakumod
+++ b/lib/MCP/Server/Prompt.rakumod
@@ -71,35 +71,11 @@ class RegisteredPrompt is export {
 
     #| Generate the prompt messages
     method get(%arguments --> Array) {
-        my $result;
-        my $called = False;
-        {
-            $result = &!generator(:params(%arguments));
-            $called = True;
-            CATCH {
-                when X::AdHoc | X::Multi::NoMatch { }
-                default { .rethrow }
-            }
-        }
-        unless $called {
-            $result = &!generator(|%arguments);
-            $called = True;
-            CATCH {
-                when X::AdHoc | X::Multi::NoMatch { }
-                default { .rethrow }
-            }
-        }
-        unless $called {
-            $result = &!generator(%arguments);
-            $called = True;
-            CATCH {
-                when X::AdHoc | X::Multi::NoMatch { }
-                default { .rethrow }
-            }
-        }
-        unless $called {
-            $result = &!generator();
-        }
+        my $result =
+            (try &!generator(:params(%arguments)))
+            // (try &!generator(|%arguments))
+            // (try &!generator(%arguments))
+            // &!generator();
 
         # Normalize to array of PromptMessage
         given $result {

--- a/lib/MCP/Server/Tool.rakumod
+++ b/lib/MCP/Server/Tool.rakumod
@@ -98,35 +98,11 @@ class RegisteredTool is export {
 
     #| Call the tool with given arguments
     method call(%arguments --> MCP::Types::CallToolResult) {
-        my $result;
-        my $called = False;
-        {
-            $result = &!handler(:params(%arguments));
-            $called = True;
-            CATCH {
-                when X::AdHoc | X::Multi::NoMatch { }
-                default { .rethrow }
-            }
-        }
-        unless $called {
-            $result = &!handler(|%arguments);
-            $called = True;
-            CATCH {
-                when X::AdHoc | X::Multi::NoMatch { }
-                default { .rethrow }
-            }
-        }
-        unless $called {
-            $result = &!handler(%arguments);
-            $called = True;
-            CATCH {
-                when X::AdHoc | X::Multi::NoMatch { }
-                default { .rethrow }
-            }
-        }
-        unless $called {
-            $result = &!handler();
-        }
+        my $result =
+            (try &!handler(:params(%arguments)))
+            // (try &!handler(|%arguments))
+            // (try &!handler(%arguments))
+            // &!handler();
 
         # Normalize result to CallToolResult
         given $result {


### PR DESCRIPTION
Replace verbose try/catch/flag dispatch pattern with idiomatic `(try &handler(...)) // ...` chains in handler call methods.
