### PR TITLE
Simplify mutators by binding parameters directly to attributes

### DIFF
--- a/lib/MCP/Server/Prompt.rakumod
+++ b/lib/MCP/Server/Prompt.rakumod
@@ -110,20 +110,11 @@ class PromptBuilder is export {
     has @!arguments;
     has &!generator;
 
-    method name(Str $name --> PromptBuilder) {
-        $!name = $name;
-        self
-    }
+    method name(Str $!name --> PromptBuilder) { self }
 
-    method description(Str $desc --> PromptBuilder) {
-        $!description = $desc;
-        self
-    }
+    method description(Str $!description --> PromptBuilder) { self }
 
-    method title(Str $t --> PromptBuilder) {
-        $!title = $t;
-        self
-    }
+    method title(Str $!title --> PromptBuilder) { self }
 
     method icon(Str $src, Str :$mimeType, :@sizes --> PromptBuilder) {
         @!icons.push(MCP::Types::IconDefinition.new(:$src, :$mimeType, :@sizes));
@@ -148,10 +139,7 @@ class PromptBuilder is export {
         self.argument($name, :$description, :!required)
     }
 
-    method generator(&generator --> PromptBuilder) {
-        &!generator = &generator;
-        self
-    }
+    method generator(&!generator --> PromptBuilder) { self }
 
     method build(--> RegisteredPrompt) {
         die "Prompt name is required" unless $!name;

--- a/lib/MCP/Server/Resource.rakumod
+++ b/lib/MCP/Server/Resource.rakumod
@@ -141,45 +141,27 @@ class ResourceBuilder is export {
     has MCP::Types::Annotations $!annotations;
     has &!reader;
 
-    method uri(Str $uri --> ResourceBuilder) {
-        $!uri = $uri;
-        self
-    }
+    method uri(Str $!uri --> ResourceBuilder) { self }
 
-    method name(Str $name --> ResourceBuilder) {
-        $!name = $name;
-        self
-    }
+    method name(Str $!name --> ResourceBuilder) { self }
 
-    method description(Str $desc --> ResourceBuilder) {
-        $!description = $desc;
-        self
-    }
+    method description(Str $!description --> ResourceBuilder) { self }
 
-    method title(Str $t --> ResourceBuilder) {
-        $!title = $t;
-        self
-    }
+    method title(Str $!title --> ResourceBuilder) { self }
 
     method icon(Str $src, Str :$mimeType, :@sizes --> ResourceBuilder) {
         @!icons.push(MCP::Types::IconDefinition.new(:$src, :$mimeType, :@sizes));
         self
     }
 
-    method mimeType(Str $mime --> ResourceBuilder) {
-        $!mimeType = $mime;
-        self
-    }
+    method mimeType(Str $!mimeType --> ResourceBuilder) { self }
 
     method annotations(@audience, Real :$priority --> ResourceBuilder) {
         $!annotations = MCP::Types::Annotations.new(:@audience, priority => $priority.Num);
         self
     }
 
-    method reader(&reader --> ResourceBuilder) {
-        &!reader = &reader;
-        self
-    }
+    method reader(&!reader --> ResourceBuilder) { self }
 
     #| Helper for file-based resources
     method from-file(IO::Path $path --> ResourceBuilder) {
@@ -362,45 +344,27 @@ class ResourceTemplateBuilder is export {
     has MCP::Types::Annotations $!annotations;
     has &!reader;
 
-    method uri-template(Str $t --> ResourceTemplateBuilder) {
-        $!uri-template = $t;
-        self
-    }
+    method uri-template(Str $!uri-template --> ResourceTemplateBuilder) { self }
 
-    method name(Str $name --> ResourceTemplateBuilder) {
-        $!name = $name;
-        self
-    }
+    method name(Str $!name --> ResourceTemplateBuilder) { self }
 
-    method description(Str $desc --> ResourceTemplateBuilder) {
-        $!description = $desc;
-        self
-    }
+    method description(Str $!description --> ResourceTemplateBuilder) { self }
 
-    method title(Str $t --> ResourceTemplateBuilder) {
-        $!title = $t;
-        self
-    }
+    method title(Str $!title --> ResourceTemplateBuilder) { self }
 
     method icon(Str $src, Str :$mimeType, :@sizes --> ResourceTemplateBuilder) {
         @!icons.push(MCP::Types::IconDefinition.new(:$src, :$mimeType, :@sizes));
         self
     }
 
-    method mimeType(Str $mime --> ResourceTemplateBuilder) {
-        $!mimeType = $mime;
-        self
-    }
+    method mimeType(Str $!mimeType --> ResourceTemplateBuilder) { self }
 
     method annotations(@audience, Real :$priority --> ResourceTemplateBuilder) {
         $!annotations = MCP::Types::Annotations.new(:@audience, priority => $priority.Num);
         self
     }
 
-    method reader(&reader --> ResourceTemplateBuilder) {
-        &!reader = &reader;
-        self
-    }
+    method reader(&!reader --> ResourceTemplateBuilder) { self }
 
     method build(--> RegisteredResourceTemplate) {
         die "Resource template URI template is required" unless $!uri-template;

--- a/lib/MCP/Server/Tool.rakumod
+++ b/lib/MCP/Server/Tool.rakumod
@@ -153,40 +153,22 @@ class ToolBuilder is export {
     has MCP::Types::TaskExecution $!execution;
     has &!handler;
 
-    method name(Str $name --> ToolBuilder) {
-        $!name = $name;
-        self
-    }
+    method name(Str $!name --> ToolBuilder) { self }
 
-    method description(Str $desc --> ToolBuilder) {
-        $!description = $desc;
-        self
-    }
+    method description(Str $!description --> ToolBuilder) { self }
 
-    method title(Str $t --> ToolBuilder) {
-        $!title = $t;
-        self
-    }
+    method title(Str $!title --> ToolBuilder) { self }
 
     method icon(Str $src, Str :$mimeType, :@sizes --> ToolBuilder) {
         @!icons.push(MCP::Types::IconDefinition.new(:$src, :$mimeType, :@sizes));
         self
     }
 
-    method schema(Hash $schema --> ToolBuilder) {
-        $!inputSchema = $schema;
-        self
-    }
+    method schema(Hash $!inputSchema --> ToolBuilder) { self }
 
-    method input-schema(Hash $schema --> ToolBuilder) {
-        $!inputSchema = $schema;
-        self
-    }
+    method input-schema(Hash $!inputSchema --> ToolBuilder) { self }
 
-    method output-schema(Hash $schema --> ToolBuilder) {
-        $!outputSchema = $schema;
-        self
-    }
+    method output-schema(Hash $!outputSchema --> ToolBuilder) { self }
 
     #| Add a string parameter
     method string-param(Str $name, Str :$description, Bool :$required --> ToolBuilder) {
@@ -273,10 +255,7 @@ class ToolBuilder is export {
         self
     }
 
-    method handler(&handler --> ToolBuilder) {
-        &!handler = &handler;
-        self
-    }
+    method handler(&!handler --> ToolBuilder) { self }
 
     method build(--> RegisteredTool) {
         die "Tool name is required" unless $!name;


### PR DESCRIPTION
Replace verbose `method foo($x) { $!x = $x; self }` with `method foo($!x) { self }` across all builder classes.
