### PR TITLE
Simplify initialization: use public attributes in builders (#142)

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.32.4",
+    "version": "0.32.5",
     "api": "1",
     "perl": "6.d",
     "auth": "zef:wkusnierczyk",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.32.4
+VERSION         := 0.32.5
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk

--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ Building this repository was supported by:
 $ make about
 
 Raku MCP SDK: Raku Implementation of the Model Context Protocol
-├─ version:    0.32.4
+├─ version:    0.32.5
 ├─ developer:  mailto:waclaw.kusnierczyk@gmail.com
 ├─ source:     https://github.com/wkusnierczyk/raku-mcp-sdk
 └─ licence:    MIT https://opensource.org/licenses/MIT

--- a/lib/MCP/Server/Prompt.rakumod
+++ b/lib/MCP/Server/Prompt.rakumod
@@ -103,12 +103,12 @@ class RegisteredPrompt is export {
 
 #| Builder for creating prompt definitions
 class PromptBuilder is export {
-    has Str $!name;
-    has Str $!description;
-    has Str $!title;
-    has @!icons;
-    has @!arguments;
-    has &!generator;
+    has Str $.name;
+    has Str $.description;
+    has Str $.title;
+    has @.icons;
+    has @.arguments;
+    has &.generator;
 
     method name(Str $name --> PromptBuilder) {
         $!name = $name;

--- a/lib/MCP/Server/Resource.rakumod
+++ b/lib/MCP/Server/Resource.rakumod
@@ -132,14 +132,14 @@ class RegisteredResource is export {
 
 #| Builder for creating resource definitions
 class ResourceBuilder is export {
-    has Str $!uri;
-    has Str $!name;
-    has Str $!description;
-    has Str $!title;
-    has @!icons;
-    has Str $!mimeType;
-    has MCP::Types::Annotations $!annotations;
-    has &!reader;
+    has Str $.uri;
+    has Str $.name;
+    has Str $.description;
+    has Str $.title;
+    has @.icons;
+    has Str $.mimeType;
+    has MCP::Types::Annotations $.annotations;
+    has &.reader;
 
     method uri(Str $uri --> ResourceBuilder) {
         $!uri = $uri;
@@ -353,14 +353,14 @@ class RegisteredResourceTemplate is export {
 
 #| Builder for creating resource template definitions
 class ResourceTemplateBuilder is export {
-    has Str $!uri-template;
-    has Str $!name;
-    has Str $!description;
-    has Str $!title;
-    has @!icons;
-    has Str $!mimeType;
-    has MCP::Types::Annotations $!annotations;
-    has &!reader;
+    has Str $.uri-template;
+    has Str $.name;
+    has Str $.description;
+    has Str $.title;
+    has @.icons;
+    has Str $.mimeType;
+    has MCP::Types::Annotations $.annotations;
+    has &.reader;
 
     method uri-template(Str $t --> ResourceTemplateBuilder) {
         $!uri-template = $t;

--- a/lib/MCP/Server/Tool.rakumod
+++ b/lib/MCP/Server/Tool.rakumod
@@ -143,15 +143,15 @@ class RegisteredTool is export {
 
 #| Builder for creating tool definitions
 class ToolBuilder is export {
-    has Str $!name;
-    has Str $!description;
-    has Str $!title;
-    has @!icons;
-    has Hash $!inputSchema = { type => 'object', properties => {}, required => [] };
-    has Hash $!outputSchema;
-    has MCP::Types::ToolAnnotations $!annotations;
-    has MCP::Types::TaskExecution $!execution;
-    has &!handler;
+    has Str $.name;
+    has Str $.description;
+    has Str $.title;
+    has @.icons;
+    has Hash $.inputSchema = { type => 'object', properties => {}, required => [] };
+    has Hash $.outputSchema;
+    has MCP::Types::ToolAnnotations $.annotations;
+    has MCP::Types::TaskExecution $.execution;
+    has &.handler;
 
     method name(Str $name --> ToolBuilder) {
         $!name = $name;


### PR DESCRIPTION
Change builder class attributes from private ($!) to public ($.) so they can be set via constructor in addition to chaining.
