### PR TITLE
[BUG] OAuth::Client form-encode body incompatible with Cro HTTP serializer

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.33.0",
+    "version": "0.33.1",
     "api": "1",
     "perl": "6.d",
     "auth": "zef:wkusnierczyk",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.33.0
+VERSION         := 0.33.1
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk

--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ Building this repository was supported by:
 $ make about
 
 Raku MCP SDK: Raku Implementation of the Model Context Protocol
-├─ version:    0.33.0
+├─ version:    0.33.1
 ├─ developer:  mailto:waclaw.kusnierczyk@gmail.com
 ├─ source:     https://github.com/wkusnierczyk/raku-mcp-sdk
 └─ licence:    MIT https://opensource.org/licenses/MIT

--- a/lib/MCP/OAuth/Client.rakumod
+++ b/lib/MCP/OAuth/Client.rakumod
@@ -142,7 +142,7 @@ class OAuthClientHandler is export {
             my $resp = await $client.post(
                 $!auth-metadata.token-endpoint,
                 content-type => 'application/x-www-form-urlencoded',
-                body => self!form-encode(%body),
+                body => %body,
             );
             my $body = await $resp.body;
             my %token-data = $body ~~ Hash ?? $body !! from-json($body);
@@ -168,7 +168,7 @@ class OAuthClientHandler is export {
             my $resp = await $client.post(
                 $!auth-metadata.token-endpoint,
                 content-type => 'application/x-www-form-urlencoded',
-                body => self!form-encode(%body),
+                body => %body,
             );
             my $body = await $resp.body;
             my %token-data = $body ~~ Hash ?? $body !! from-json($body);
@@ -235,10 +235,6 @@ class OAuthClientHandler is export {
             await self.authenticate;
             True
         }
-    }
-
-    method !form-encode(%data --> Str) {
-        %data.kv.map(-> $k, $v { "{uri-encode($k)}={uri-encode($v)}" }).join('&')
     }
 
     method !cro-client() {
@@ -327,7 +323,7 @@ class OAuthM2MClient is export {
             my $resp = await $client.post(
                 $!auth-metadata.token-endpoint,
                 content-type => 'application/x-www-form-urlencoded',
-                body => self!form-encode(%body),
+                body => %body,
             );
             my $body = await $resp.body;
             my %token-data = $body ~~ Hash ?? $body !! from-json($body);
@@ -353,10 +349,6 @@ class OAuthM2MClient is export {
         }
     }
 
-    method !form-encode(%data --> Str) {
-        %data.kv.map(-> $k, $v { "{uri-encode($k)}={uri-encode($v)}" }).join('&')
-    }
-
     method !cro-client() {
         require ::('Cro::HTTP::Client');
         return ::('Cro::HTTP::Client').new;
@@ -367,10 +359,6 @@ class OAuthM2MClient is export {
                 );
             }
         }
-    }
-
-    sub uri-encode(Str $s --> Str) {
-        $s.subst(/<-[A..Za..z0..9\-._~]>/, { .Str.encode('utf-8').list.map({ '%' ~ .fmt('%02X') }).join }, :g)
     }
 }
 
@@ -453,7 +441,7 @@ class OAuthEnterpriseClient is export {
             my $resp = await $client.post(
                 $!idp-token-endpoint,
                 content-type => 'application/x-www-form-urlencoded',
-                body => self!form-encode(%body),
+                body => %body,
             );
             my $body = await $resp.body;
             my %data = $body ~~ Hash ?? $body !! from-json($body);
@@ -487,7 +475,7 @@ class OAuthEnterpriseClient is export {
             my $resp = await $client.post(
                 $!auth-metadata.token-endpoint,
                 content-type => 'application/x-www-form-urlencoded',
-                body => self!form-encode(%body),
+                body => %body,
             );
             my $body = await $resp.body;
             my %token-data = $body ~~ Hash ?? $body !! from-json($body);
@@ -524,10 +512,6 @@ class OAuthEnterpriseClient is export {
         }
     }
 
-    method !form-encode(%data --> Str) {
-        %data.kv.map(-> $k, $v { "{uri-encode($k)}={uri-encode($v)}" }).join('&')
-    }
-
     method !cro-client() {
         require ::('Cro::HTTP::Client');
         return ::('Cro::HTTP::Client').new;
@@ -538,9 +522,5 @@ class OAuthEnterpriseClient is export {
                 );
             }
         }
-    }
-
-    sub uri-encode(Str $s --> Str) {
-        $s.subst(/<-[A..Za..z0..9\-._~]>/, { .Str.encode('utf-8').list.map({ '%' ~ .fmt('%02X') }).join }, :g)
     }
 }


### PR DESCRIPTION
## Summary

Fix OAuth client form-encode body incompatibility with Cro HTTP serializer (#153).

- **Pass `%body` hash directly** to Cro's `post()` instead of pre-encoding to a string via `!form-encode()`. Cro's body serializer rejects `Str` for `application/x-www-form-urlencoded` content type, expecting an `Associative` instead.
- **Remove dead code**: `!form-encode` private methods from all three OAuth client classes (`OAuthClientHandler`, `OAuthM2MClient`, `OAuthEnterpriseClient`) and `uri-encode` subs from `OAuthM2MClient` and `OAuthEnterpriseClient` (retained in `OAuthClientHandler` where `authorization-url` still uses it).

## Affected call sites

- `OAuthClientHandler.exchange-code()` — token exchange
- `OAuthClientHandler.refresh()` — token refresh
- `OAuthM2MClient.request-token()` — client credentials grant
- `OAuthEnterpriseClient.exchange-token()` — IdP token exchange (RFC 8693)
- `OAuthEnterpriseClient.request-token()` — JWT bearer grant (RFC 7523)

## Test plan

- [x] `make test` — all 307 tests pass, no regressions
- [x] Syntax check on `lib/MCP/OAuth/Client.rakumod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)