### PR TITLE
Fix fez upload failure in CI — FEZ_CONFIG env var collision (#156)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,14 +350,14 @@ jobs:
 
       - name: Configure fez
         env:
-          FEZ_CONFIG: ${{ secrets.FEZ_CONFIG }}
+          FEZ_CONFIG_CONTENT: ${{ secrets.FEZ_CONFIG }}
         run: |
-          if [[ -z "$FEZ_CONFIG" ]]; then
+          if [[ -z "$FEZ_CONFIG_CONTENT" ]]; then
             echo "::warning::FEZ_CONFIG secret not set, skipping publish"
             exit 0
           fi
 
-          printf '%s' "$FEZ_CONFIG" > ~/.fez-config.json
+          printf '%s' "$FEZ_CONFIG_CONTENT" > ~/.fez-config.json
           chmod 600 ~/.fez-config.json
 
           # Ensure fez has a working HTTP requestor (curl is pre-installed on ubuntu)
@@ -368,12 +368,12 @@ jobs:
             echo "✓ Added Fez::Util::Curl requestor to fez config" >&2
           fi
 
+          echo "✓ Fez configured" >&2
+
       - name: Publish to Zef ecosystem
-        env:
-          FEZ_CONFIG: ${{ secrets.FEZ_CONFIG }}
         run: |
-          if [[ -z "$FEZ_CONFIG" ]]; then
-            echo "::warning::Skipping publish - FEZ_CONFIG not configured"
+          if [[ ! -f ~/.fez-config.json ]]; then
+            echo "::warning::Skipping publish - fez config not found"
             exit 0
           fi
 

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "MCP",
     "description": "Model Context Protocol SDK for Raku - Build MCP servers and clients",
-    "version": "0.33.1",
+    "version": "0.33.2",
     "api": "1",
     "perl": "6.d",
     "auth": "zef:wkusnierczyk",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PROJECT_NAME    := MCP
 PROJECT_TITLE   := Raku MCP SDK
 PROJECT_DESC    := Raku Implementation of the Model Context Protocol
-VERSION         := 0.33.1
+VERSION         := 0.33.2
 DEVELOPER_NAME  := Waclaw Kusnierczyk
 DEVELOPER_EMAIL := waclaw.kusnierczyk@gmail.com
 SOURCE_URL      := https://github.com/wkusnierczyk/raku-mcp-sdk

--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ Building this repository was supported by:
 $ make about
 
 Raku MCP SDK: Raku Implementation of the Model Context Protocol
-├─ version:    0.33.1
+├─ version:    0.33.2
 ├─ developer:  mailto:waclaw.kusnierczyk@gmail.com
 ├─ source:     https://github.com/wkusnierczyk/raku-mcp-sdk
 └─ licence:    MIT https://opensource.org/licenses/MIT


### PR DESCRIPTION
## Summary

Fix the `fez upload` step in the release workflow which fails with:

```
Use of uninitialized value $h of type Any in string context.
  in code at ... (Fez::Web) line 12
===SORRY!=== Error while compiling ...
Unable to find a suitable handler for web (tried )
```

## Root cause

Fez v100.0.2 reads `%*ENV<FEZ_CONFIG>` as its environment config source. The workflow was setting `FEZ_CONFIG` as an env var containing raw JSON secret content (auth credentials). Fez tried to use this as its config, failed to parse handler names from it, and `Fez::Web` ended up with uninitialized `@handlers`.

## Fix

- **Rename** the env var from `FEZ_CONFIG` to `FEZ_CONFIG_CONTENT` in the configure step, so it doesn't collide with fez's internal env var
- **Remove** the env var from the upload step entirely — fez reads `~/.fez-config.json` directly
- **Check** for the config file existence instead of the env var in the upload step guard

## Test plan

- [ ] Trigger a release tag push and verify `fez upload` succeeds
- [x] YAML validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)