### PR TITLE
Use roll instead of map/pick for random strings

### DIFF
--- a/lib/MCP/OAuth.rakumod
+++ b/lib/MCP/OAuth.rakumod
@@ -268,7 +268,7 @@ class ClientRegistrationResponse is export {
 class PKCE is export {
     method generate-verifier(--> Str) {
         my @chars = flat('A'..'Z', 'a'..'z', '0'..'9', '-', '.', '_', '~');
-        (^64).map({ @chars.pick }).join
+        @chars.roll(64).join
     }
 
     method generate-challenge(Str $verifier --> Str) {

--- a/lib/MCP/OAuth/Client.rakumod
+++ b/lib/MCP/OAuth/Client.rakumod
@@ -97,7 +97,7 @@ class OAuthClientHandler is export {
         $!pkce-verifier = $pkce.generate-verifier;
         my $challenge = $pkce.generate-challenge($!pkce-verifier);
 
-        my $state = (^32).map({ <a b c d e f 0 1 2 3 4 5 6 7 8 9>.pick }).join;
+        my $state = <a b c d e f 0 1 2 3 4 5 6 7 8 9>.roll(32).join;
 
         my $endpoint = $!auth-metadata.authorization-endpoint;
         my @params;

--- a/lib/MCP/Transport/StreamableHTTP.rakumod
+++ b/lib/MCP/Transport/StreamableHTTP.rakumod
@@ -477,12 +477,12 @@ class StreamableHTTPServerTransport does MCP::Transport::Base::Transport is expo
     }
 
     method !new-stream-id(--> Str) {
-        my $rand = (0..^16).map({ <a b c d e f 0 1 2 3 4 5 6 7 8 9>.pick }).join;
+        my $rand = <a b c d e f 0 1 2 3 4 5 6 7 8 9>.roll(16).join;
         "s{$rand}"
     }
 
     method !new-session-id(--> Str) {
-        my $rand = (0..^31).map({ <a b c d e f 0 1 2 3 4 5 6 7 8 9>.pick }).join;
+        my $rand = <a b c d e f 0 1 2 3 4 5 6 7 8 9>.roll(31).join;
         "session-$rand"
     }
 


### PR DESCRIPTION
## Summary

- Replace `(^N).map({ list.pick }).join` with `list.roll(N).join` in 4 locations
- More idiomatic Raku pattern for generating random strings

Closes #166

## Test plan

- [x] All 324 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)