### PR TITLE
Use with/without instead of .defined in conditionals

### DIFF
--- a/lib/MCP/Client.rakumod
+++ b/lib/MCP/Client.rakumod
@@ -297,7 +297,7 @@ class Client is export {
             %capabilities<roots> = { listChanged => True };
         }
         # Add elicitation capability if handler is configured
-        if &!elicitation-handler.defined {
+        with &!elicitation-handler {
             %capabilities<elicitation> //= {};
             %capabilities<elicitation><form> = {};
         }
@@ -747,7 +747,7 @@ class Client is export {
     }
 
     method !handle-sampling-request(MCP::JSONRPC::Request $req) {
-        unless &!sampling-handler.defined {
+        without &!sampling-handler {
             my $error = MCP::JSONRPC::Error.from-code(
                 MCP::JSONRPC::MethodNotFound,
                 "Client does not support method: {$req.method}"
@@ -785,8 +785,8 @@ class Client is export {
 
         my $failure = $!;
         my $response;
-        if $failure.defined {
-            my $ex = $failure ~~ Failure ?? $failure.exception !! $failure;
+        with $failure {
+            my $ex = $_ ~~ Failure ?? .exception !! $_;
             if $ex ~~ X::MCP::Client::Error {
                 $response = MCP::JSONRPC::Response.error($req.id, $ex.error);
             } else {
@@ -923,7 +923,7 @@ class Client is export {
 
     #| Handle elicitation/create request from server
     method !handle-elicitation-request(MCP::JSONRPC::Request $req) {
-        unless &!elicitation-handler.defined {
+        without &!elicitation-handler {
             my $error = MCP::JSONRPC::Error.from-code(
                 MCP::JSONRPC::MethodNotFound,
                 "Client does not support elicitation"
@@ -959,8 +959,8 @@ class Client is export {
 
         my $failure = $!;
         my $response;
-        if $failure.defined {
-            my $ex = $failure ~~ Failure ?? $failure.exception !! $failure;
+        with $failure {
+            my $ex = $_ ~~ Failure ?? .exception !! $_;
             if $ex ~~ X::MCP::Client::Error {
                 $response = MCP::JSONRPC::Response.error($req.id, $ex.error);
             } else {

--- a/lib/MCP/Client.rakumod
+++ b/lib/MCP/Client.rakumod
@@ -783,10 +783,9 @@ class Client is export {
             $out
         };
 
-        my $failure = $!;
         my $response;
-        with $failure {
-            my $ex = $_ ~~ Failure ?? .exception !! $_;
+        with $! -> $failure {
+            my $ex = $failure ~~ Failure ?? $failure.exception !! $failure;
             if $ex ~~ X::MCP::Client::Error {
                 $response = MCP::JSONRPC::Response.error($req.id, $ex.error);
             } else {
@@ -957,10 +956,9 @@ class Client is export {
             $out
         };
 
-        my $failure = $!;
         my $response;
-        with $failure {
-            my $ex = $_ ~~ Failure ?? .exception !! $_;
+        with $! -> $failure {
+            my $ex = $failure ~~ Failure ?? $failure.exception !! $failure;
             if $ex ~~ X::MCP::Client::Error {
                 $response = MCP::JSONRPC::Response.error($req.id, $ex.error);
             } else {

--- a/lib/MCP/JSONRPC.rakumod
+++ b/lib/MCP/JSONRPC.rakumod
@@ -166,8 +166,8 @@ class Response does Message is export {
     #| Serialize the response into a Hash
     method Hash(--> Hash) {
         my %h = :$!jsonrpc, :$!id;
-        if $!error.defined {
-            %h<error> = $!error.Hash;
+        with $!error {
+            %h<error> = .Hash;
         } else {
             %h<result> = $!result;
         }

--- a/lib/MCP/OAuth.rakumod
+++ b/lib/MCP/OAuth.rakumod
@@ -145,7 +145,7 @@ class TokenResponse is export {
     has Instant $.created-at = now;
 
     method is-expired(--> Bool) {
-        return False unless $!expires-in.defined;
+        return False without $!expires-in;
         my $expiry = $!created-at + $!expires-in - 30; # 30s buffer
         now > $expiry
     }
@@ -282,8 +282,8 @@ class PKCE is export {
         try {
             my $mod = (require ::('Digest::SHA256::Native'));
             my &sha256-func = ::('Digest::SHA256::Native').WHO<&sha256>;
-            if &sha256-func.defined {
-                return sha256-func($data);
+            with &sha256-func {
+                return $_($data);
             }
         }
         # Pure Raku fallback to avoid platform-specific native toolchains.

--- a/lib/MCP/OAuth/Client.rakumod
+++ b/lib/MCP/OAuth/Client.rakumod
@@ -91,7 +91,7 @@ class OAuthClientHandler is export {
 
     method authorization-url(--> Str) {
         die X::MCP::OAuth::Discovery.new(message => 'Must call discover() first')
-            unless $!auth-metadata.defined;
+            without $!auth-metadata;
 
         my $pkce = PKCE.new;
         $!pkce-verifier = $pkce.generate-verifier;

--- a/lib/MCP/Server.rakumod
+++ b/lib/MCP/Server.rakumod
@@ -354,11 +354,11 @@ class Server is export {
         for @args -> $arg {
             my %a = $arg ~~ Pair ?? { $arg.key => $arg.value } !! $arg;
             my $arg-name = %a<name>;
-            die "Prompt argument name is required" unless $arg-name.defined;
+            die "Prompt argument name is required" without $arg-name;
             my $req = %a<required> // False;
             my $desc = %a<description>;
-            if $desc.defined {
-                $builder.argument($arg-name, description => $desc, required => $req);
+            with $desc {
+                $builder.argument($arg-name, description => $_, required => $req);
             } else {
                 $builder.argument($arg-name, required => $req);
             }
@@ -650,10 +650,10 @@ class Server is export {
             when 'notifications/cancelled' | 'cancelled' {
                 # Request was cancelled - mark it so we don't send a response
                 my $id = $notif.params<requestId>;
-                if $id.defined {
+                with $id {
                     $!flight-lock.protect: {
-                        if %!in-flight-requests{$id}:exists {
-                            %!in-flight-requests{$id}<cancelled> = True;
+                        if %!in-flight-requests{$_}:exists {
+                            %!in-flight-requests{$_}<cancelled> = True;
                         }
                     }
                 }
@@ -909,10 +909,10 @@ class Server is export {
         # Try matching against resource templates
         for %!resource-templates.values -> $template {
             my $match = $template.match-uri($uri);
-            if $match.defined {
-                return {
-                    contents => $template.read($match, uri => $uri).map(*.Hash).Array
-                };
+            with $match {
+                return %(
+                    contents => $template.read($_, uri => $uri).map(*.Hash).Array
+                );
             }
         }
 
@@ -1022,7 +1022,7 @@ class Server is export {
     #| If no token is provided, uses the progress token from the current request's _meta
     method progress(Num $progress, Num :$total, Str :$message, :$token is copy) {
         $token //= $*MCP-PROGRESS-TOKEN // Nil;
-        return unless $token.defined;
+        return without $token;
         self.notify('notifications/progress', {
             progressToken => $token,
             progress => $progress,

--- a/lib/MCP/Server/Resource.rakumod
+++ b/lib/MCP/Server/Resource.rakumod
@@ -271,7 +271,7 @@ class RegisteredResourceTemplate is export {
                 # Find the next literal to know where this variable ends
                 if $literal.chars {
                     my $pos = $remaining.index($literal);
-                    return Nil unless $pos.defined;
+                    return Nil without $pos;
                     my $val = $remaining.substr(0, $pos);
                     return Nil unless $val.chars;  # empty variable
                     @values.push: $val;


### PR DESCRIPTION
## Summary

- Replace `if $x.defined` with `with $x` and `unless $x.defined` with `without $x`
- Use `$_` or `.method` inside blocks where the value is referenced
- One case required `%()` instead of `{}` to avoid Block/Hash parsing ambiguity

Changes across 6 files, 14 locations.

Note: Many remaining `.defined` patterns are postfix conditionals (issue #168) or chained conditions.

Closes #167

## Test plan

- [x] All 324 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)