### PR TITLE
Use junction in Task.is-terminal instead of chained ||

### DIFF
--- a/lib/MCP/Types.rakumod
+++ b/lib/MCP/Types.rakumod
@@ -396,7 +396,7 @@ class Task is export {
     }
 
     method is-terminal(--> Bool) {
-        $!status === TaskCompleted || $!status === TaskFailed || $!status === TaskCancelled
+        so $!status === any(TaskCompleted, TaskFailed, TaskCancelled)
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace chained `$!status === X || $!status === Y || $!status === Z` with `so $!status === any(X, Y, Z)`
- The `so` prefix collapses the junction result to a Bool for the return type constraint

Closes #169

## Test plan

- [x] All 324 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)