### PR TITLE
Use .trans instead of chained .subst calls in PKCE base64url

### DIFF
--- a/lib/MCP/OAuth.rakumod
+++ b/lib/MCP/OAuth.rakumod
@@ -406,10 +406,6 @@ class PKCE is export {
     }
 
     method !base64url(Blob $data --> Str) {
-        my $encoded = MIME::Base64.encode($data, :oneline);
-        $encoded = $encoded.subst('+', '-', :g);
-        $encoded = $encoded.subst('/', '_', :g);
-        $encoded = $encoded.subst('=', '', :g);
-        $encoded
+        MIME::Base64.encode($data, :oneline).trans('+' => '-', '/' => '_', '=' => '')
     }
 }


### PR DESCRIPTION
## Summary

- Replace three chained `.subst` calls with a single `.trans` call
- More concise (5 lines → 1) and efficient

Closes #170

## Test plan

- [x] All 324 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)