### PR TITLE
Extract helper for repeated JSONRPC InvalidParams error construction

### DIFF
--- a/lib/MCP/Server.rakumod
+++ b/lib/MCP/Server.rakumod
@@ -224,6 +224,13 @@ class Server is export {
         from-json($json)<offset>
     }
 
+    #| Throw InvalidParams error with given message
+    method !invalid-params(Str $msg) {
+        die X::MCP::JSONRPC.new(
+            error => MCP::JSONRPC::Error.from-code(MCP::JSONRPC::InvalidParams, $msg)
+        );
+    }
+
     #| Paginate a list of items
     method !paginate(@items, $params, Str :$key! --> Hash) {
         my Int $offset = 0;
@@ -232,14 +239,7 @@ class Server is export {
             {
                 $offset = self!decode-cursor($params<cursor>);
                 CATCH {
-                    default {
-                        die X::MCP::JSONRPC.new(
-                            error => MCP::JSONRPC::Error.from-code(
-                                MCP::JSONRPC::InvalidParams,
-                                "Invalid cursor"
-                            )
-                        );
-                    }
+                    default { self!invalid-params("Invalid cursor") }
                 }
             }
         }
@@ -621,22 +621,10 @@ class Server is export {
 
     #| Handle logging/setLevel request
     method !handle-set-log-level(%params) {
-        my $level-str = %params<level> // die X::MCP::JSONRPC.new(
-            error => MCP::JSONRPC::Error.from-code(
-                MCP::JSONRPC::InvalidParams,
-                "Missing required parameter: level"
-            )
-        );
+        my $level-str = %params<level> // self!invalid-params("Missing required parameter: level");
         $!log-level = parse-log-level($level-str);
         CATCH {
-            when X::AdHoc {
-                die X::MCP::JSONRPC.new(
-                    error => MCP::JSONRPC::Error.from-code(
-                        MCP::JSONRPC::InvalidParams,
-                        "Invalid log level: $level-str"
-                    )
-                );
-            }
+            when X::AdHoc { self!invalid-params("Invalid log level: $level-str") }
         }
         {}
     }
@@ -695,19 +683,8 @@ class Server is export {
 
     #| Call a tool
     method !call-tool(%params) {
-        my $name = %params<name> // die X::MCP::JSONRPC.new(
-            error => MCP::JSONRPC::Error.from-code(
-                MCP::JSONRPC::InvalidParams,
-                "Missing required parameter: name"
-            )
-        );
-
-        my $tool = %!tools{$name} // die X::MCP::JSONRPC.new(
-            error => MCP::JSONRPC::Error.from-code(
-                MCP::JSONRPC::InvalidParams,
-                "Unknown tool: $name"
-            )
-        );
+        my $name = %params<name> // self!invalid-params("Missing required parameter: name");
+        my $tool = %!tools{$name} // self!invalid-params("Unknown tool: $name");
 
         # If task hint is present, run as async task
         if %params<task> && %params<task><ttl> {
@@ -785,42 +762,19 @@ class Server is export {
 
     #| Get a task by ID
     method !get-task(%params --> Hash) {
-        my $task-id = %params<taskId> // die X::MCP::JSONRPC.new(
-            error => MCP::JSONRPC::Error.from-code(
-                MCP::JSONRPC::InvalidParams,
-                "Missing required parameter: taskId"
-            )
-        );
-
+        my $task-id = %params<taskId> // self!invalid-params("Missing required parameter: taskId");
         $!task-lock.protect: {
-            my $entry = %!tasks{$task-id} // die X::MCP::JSONRPC.new(
-                error => MCP::JSONRPC::Error.from-code(
-                    MCP::JSONRPC::InvalidParams,
-                    "Unknown task: $task-id"
-                )
-            );
-
+            my $entry = %!tasks{$task-id} // self!invalid-params("Unknown task: $task-id");
             $entry<task>.Hash
         }
     }
 
     #| Get task result (blocks until terminal)
     method !get-task-result(%params --> Hash) {
-        my $task-id = %params<taskId> // die X::MCP::JSONRPC.new(
-            error => MCP::JSONRPC::Error.from-code(
-                MCP::JSONRPC::InvalidParams,
-                "Missing required parameter: taskId"
-            )
-        );
-
+        my $task-id = %params<taskId> // self!invalid-params("Missing required parameter: taskId");
         my ($entry, $completion);
         $!task-lock.protect: {
-            $entry = %!tasks{$task-id} // die X::MCP::JSONRPC.new(
-                error => MCP::JSONRPC::Error.from-code(
-                    MCP::JSONRPC::InvalidParams,
-                    "Unknown task: $task-id"
-                )
-            );
+            $entry = %!tasks{$task-id} // self!invalid-params("Unknown task: $task-id");
             $completion = $entry<completion>;
         };
 
@@ -840,20 +794,9 @@ class Server is export {
 
     #| Cancel a task
     method !cancel-task(%params --> Hash) {
-        my $task-id = %params<taskId> // die X::MCP::JSONRPC.new(
-            error => MCP::JSONRPC::Error.from-code(
-                MCP::JSONRPC::InvalidParams,
-                "Missing required parameter: taskId"
-            )
-        );
-
+        my $task-id = %params<taskId> // self!invalid-params("Missing required parameter: taskId");
         $!task-lock.protect: {
-            my $entry = %!tasks{$task-id} // die X::MCP::JSONRPC.new(
-                error => MCP::JSONRPC::Error.from-code(
-                    MCP::JSONRPC::InvalidParams,
-                    "Unknown task: $task-id"
-                )
-            );
+            my $entry = %!tasks{$task-id} // self!invalid-params("Unknown task: $task-id");
 
             unless $entry<task>.is-terminal {
                 my $now = self!iso-now;
@@ -892,12 +835,7 @@ class Server is export {
 
     #| Read a resource
     method !read-resource(%params) {
-        my $uri = %params<uri> // die X::MCP::JSONRPC.new(
-            error => MCP::JSONRPC::Error.from-code(
-                MCP::JSONRPC::InvalidParams,
-                "Missing required parameter: uri"
-            )
-        );
+        my $uri = %params<uri> // self!invalid-params("Missing required parameter: uri");
 
         # Try exact match first
         if %!resources{$uri}:exists {
@@ -916,32 +854,15 @@ class Server is export {
             }
         }
 
-        die X::MCP::JSONRPC.new(
-            error => MCP::JSONRPC::Error.from-code(
-                MCP::JSONRPC::InvalidParams,
-                "Unknown resource: $uri"
-            )
-        );
+        self!invalid-params("Unknown resource: $uri");
     }
 
     #| Subscribe to a resource
     method !subscribe-resource(%params) {
-        my $uri = %params<uri> // die X::MCP::JSONRPC.new(
-            error => MCP::JSONRPC::Error.from-code(
-                MCP::JSONRPC::InvalidParams,
-                "Missing required parameter: uri"
-            )
-        );
+        my $uri = %params<uri> // self!invalid-params("Missing required parameter: uri");
 
         # Verify resource exists
-        unless %!resources{$uri}:exists {
-            die X::MCP::JSONRPC.new(
-                error => MCP::JSONRPC::Error.from-code(
-                    MCP::JSONRPC::InvalidParams,
-                    "Unknown resource: $uri"
-                )
-            );
-        }
+        self!invalid-params("Unknown resource: $uri") unless %!resources{$uri}:exists;
 
         %!subscriptions{$uri} = True;
         {}  # Empty response on success
@@ -949,13 +870,7 @@ class Server is export {
 
     #| Unsubscribe from a resource
     method !unsubscribe-resource(%params) {
-        my $uri = %params<uri> // die X::MCP::JSONRPC.new(
-            error => MCP::JSONRPC::Error.from-code(
-                MCP::JSONRPC::InvalidParams,
-                "Missing required parameter: uri"
-            )
-        );
-
+        my $uri = %params<uri> // self!invalid-params("Missing required parameter: uri");
         %!subscriptions{$uri}:delete;
         {}  # Empty response on success
     }
@@ -968,19 +883,8 @@ class Server is export {
 
     #| Get a prompt
     method !get-prompt(%params) {
-        my $name = %params<name> // die X::MCP::JSONRPC.new(
-            error => MCP::JSONRPC::Error.from-code(
-                MCP::JSONRPC::InvalidParams,
-                "Missing required parameter: name"
-            )
-        );
-
-        my $prompt = %!prompts{$name} // die X::MCP::JSONRPC.new(
-            error => MCP::JSONRPC::Error.from-code(
-                MCP::JSONRPC::InvalidParams,
-                "Unknown prompt: $name"
-            )
-        );
+        my $name = %params<name> // self!invalid-params("Missing required parameter: name");
+        my $prompt = %!prompts{$name} // self!invalid-params("Unknown prompt: $name");
 
         my %arguments = %params<arguments> // {};
 
@@ -1062,32 +966,14 @@ class Server is export {
 
     #| Handle completion/complete request
     method !handle-completion(%params) {
-        my $ref = %params<ref> // die X::MCP::JSONRPC.new(
-            error => MCP::JSONRPC::Error.from-code(
-                MCP::JSONRPC::InvalidParams,
-                "Missing required parameter: ref"
-            )
-        );
-
-        my $argument = %params<argument> // die X::MCP::JSONRPC.new(
-            error => MCP::JSONRPC::Error.from-code(
-                MCP::JSONRPC::InvalidParams,
-                "Missing required parameter: argument"
-            )
-        );
+        my $ref = %params<ref> // self!invalid-params("Missing required parameter: ref");
+        my $argument = %params<argument> // self!invalid-params("Missing required parameter: argument");
 
         my $ref-type = $ref<type> // '';
         my $key = do given $ref-type {
             when 'ref/prompt'   { "prompt:{$ref<name> // ''}" }
             when 'ref/resource' { "resource:{$ref<uri> // ''}" }
-            default {
-                die X::MCP::JSONRPC.new(
-                    error => MCP::JSONRPC::Error.from-code(
-                        MCP::JSONRPC::InvalidParams,
-                        "Unknown ref type: $ref-type"
-                    )
-                );
-            }
+            default             { self!invalid-params("Unknown ref type: $ref-type") }
         };
 
         unless %!completers{$key}:exists {


### PR DESCRIPTION
## Summary

- Add `!invalid-params(Str $msg)` helper method
- Replace ~20 occurrences of 5-line error construction boilerplate with single-line calls
- Net reduction: **114 lines** (28 added, 142 removed)

Closes #172

## Test plan

- [x] All 324 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)