### PR TITLE
Use WhateverCode in grep instead of explicit block

### DIFF
--- a/lib/MCP/Client.rakumod
+++ b/lib/MCP/Client.rakumod
@@ -412,9 +412,7 @@ class Client is export {
 
     #| Supply of progress notifications (emits MCP::Types::Progress objects)
     method progress(--> Supply) {
-        self.notifications.grep({
-            $_.method eq 'notifications/progress'
-        }).map({
+        self.notifications.grep(*.method eq 'notifications/progress').map({
             MCP::Types::Progress.new(
                 progressToken => $_.params<progressToken>,
                 progress      => $_.params<progress>.Num,


### PR DESCRIPTION
## Summary

- Replace `grep({ $_.method eq ... })` with `grep(*.method eq ...)`
- Other grep calls with compound conditions left as-is (WhateverCode doesn't simplify them)

Closes #175

## Test plan

- [x] All 324 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)