### PR TITLE
Remove redundant .Array calls after .map

### DIFF
--- a/lib/MCP/Server.rakumod
+++ b/lib/MCP/Server.rakumod
@@ -689,7 +689,7 @@ class Server is export {
 
     #| List tools
     method !list-tools($params?) {
-        my @tools = %!tools.values.map(*.to-tool.Hash).Array;
+        my @tools = %!tools.values.map(*.to-tool.Hash);
         self!paginate(@tools, $params, key => 'tools')
     }
 
@@ -880,13 +880,13 @@ class Server is export {
 
     #| List resources
     method !list-resources($params?) {
-        my @resources = %!resources.values.map(*.to-resource.Hash).Array;
+        my @resources = %!resources.values.map(*.to-resource.Hash);
         self!paginate(@resources, $params, key => 'resources')
     }
 
     #| List resource templates
     method !list-resource-templates($params?) {
-        my @templates = %!resource-templates.values.map(*.to-resource-template.Hash).Array;
+        my @templates = %!resource-templates.values.map(*.to-resource-template.Hash);
         self!paginate(@templates, $params, key => 'resourceTemplates')
     }
 
@@ -962,7 +962,7 @@ class Server is export {
 
     #| List prompts
     method !list-prompts($params?) {
-        my @prompts = %!prompts.values.map(*.to-prompt.Hash).Array;
+        my @prompts = %!prompts.values.map(*.to-prompt.Hash);
         self!paginate(@prompts, $params, key => 'prompts')
     }
 


### PR DESCRIPTION
## Summary

- Remove `.Array` in 4 list methods where `@` variable assignment auto-coerces
- Kept `.Array` in `!list-tasks` (iteration must happen inside lock)
- Types.rakumod cases left unchanged (public API Hash serialization)

Closes #177

## Test plan

- [x] All 324 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)