### PR TITLE
Use hyper method call ».Hash instead of .map(*.Hash)

### DIFF
--- a/lib/MCP/Server.rakumod
+++ b/lib/MCP/Server.rakumod
@@ -902,7 +902,7 @@ class Server is export {
         # Try exact match first
         if %!resources{$uri}:exists {
             return {
-                contents => %!resources{$uri}.read.map(*.Hash).Array
+                contents => %!resources{$uri}.read».Hash
             };
         }
 
@@ -911,7 +911,7 @@ class Server is export {
             my $match = $template.match-uri($uri);
             with $match {
                 return %(
-                    contents => $template.read($_, uri => $uri).map(*.Hash).Array
+                    contents => $template.read($_, uri => $uri)».Hash
                 );
             }
         }
@@ -986,7 +986,7 @@ class Server is export {
 
         {
             description => $prompt.description,
-            messages => $prompt.get(%arguments).map(*.Hash).Array
+            messages => $prompt.get(%arguments)».Hash
         }
     }
 

--- a/lib/MCP/Types.rakumod
+++ b/lib/MCP/Types.rakumod
@@ -146,7 +146,7 @@ class Implementation is export {
     method Hash(--> Hash) {
         my %h = :$!name, :$!version;
         %h<title> = $_ with $!title;
-        %h<icons> = @!icons.map(*.Hash).Array if @!icons;
+        %h<icons> = @!icons».Hash if @!icons;
         %h
     }
 
@@ -314,7 +314,7 @@ class ToolResultContent does Content is export {
 
     method Hash(--> Hash) {
         my %h = type => 'tool_result', :$!toolUseId;
-        %h<content> = @!content.map(*.Hash).Array;
+        %h<content> = @!content».Hash;
         %h<isError> = $!isError if $!isError.defined;
         %h<structuredContent> = $_ with $!structuredContent;
         %h<_meta> = $_ with $!meta;
@@ -424,7 +424,7 @@ class Tool is export {
         my %h = :$!name;
         %h<description> = $_ with $!description;
         %h<title> = $_ with $!title;
-        %h<icons> = @!icons.map(*.Hash).Array if @!icons;
+        %h<icons> = @!icons».Hash if @!icons;
         %h<inputSchema> = $_ with $!inputSchema;
         %h<outputSchema> = $_ with $!outputSchema;
         %h<annotations> = $!annotations.Hash if $!annotations;
@@ -452,7 +452,7 @@ class CallToolResult is export {
     has $.structuredContent;  # Optional structured output matching outputSchema
 
     method Hash(--> Hash) {
-        my %h = content => @!content.map(*.Hash).Array, :$!isError;
+        my %h = content => @!content».Hash, :$!isError;
         %h<structuredContent> = $_ with $!structuredContent;
         %h
     }
@@ -472,7 +472,7 @@ class Resource is export {
         my %h = :$!uri, :$!name;
         %h<description> = $_ with $!description;
         %h<title> = $_ with $!title;
-        %h<icons> = @!icons.map(*.Hash).Array if @!icons;
+        %h<icons> = @!icons».Hash if @!icons;
         %h<mimeType> = $_ with $!mimeType;
         %h<annotations> = $!annotations.Hash if $!annotations;
         %h
@@ -502,7 +502,7 @@ class ResourceTemplate is export {
         my %h = :$!uriTemplate, :$!name;
         %h<description> = $_ with $!description;
         %h<title> = $_ with $!title;
-        %h<icons> = @!icons.map(*.Hash).Array if @!icons;
+        %h<icons> = @!icons».Hash if @!icons;
         %h<mimeType> = $_ with $!mimeType;
         %h<annotations> = $!annotations.Hash if $!annotations;
         %h
@@ -560,8 +560,8 @@ class Prompt is export {
         my %h = :$!name;
         %h<description> = $_ with $!description;
         %h<title> = $_ with $!title;
-        %h<icons> = @!icons.map(*.Hash).Array if @!icons;
-        %h<arguments> = @!arguments.map(*.Hash).Array if @!arguments;
+        %h<icons> = @!icons».Hash if @!icons;
+        %h<arguments> = @!arguments».Hash if @!arguments;
         %h
     }
 
@@ -584,7 +584,7 @@ class PromptMessage is export {
         {
             :$!role,
             content => $!content ~~ Positional
-                ?? $!content.map(*.Hash).Array
+                ?? $!content».Hash
                 !! $!content.Hash
         }
     }
@@ -599,7 +599,7 @@ class SamplingMessage is export {
         {
             :$!role,
             content => $!content ~~ Positional
-                ?? $!content.map(*.Hash).Array
+                ?? $!content».Hash
                 !! $!content.Hash
         }
     }
@@ -621,7 +621,7 @@ class ModelPreferences is export {
 
     method Hash(--> Hash) {
         my %h;
-        %h<hints> = @!hints.map(*.Hash).Array if @!hints;
+        %h<hints> = @!hints».Hash if @!hints;
         %h<costPriority> = $_ with $!costPriority;
         %h<speedPriority> = $_ with $!speedPriority;
         %h<intelligencePriority> = $_ with $!intelligencePriority;
@@ -652,7 +652,7 @@ class CreateMessageResult is export {
     method Hash(--> Hash) {
         my %h = :$!model, :$!role,
             content => $!content ~~ Positional
-                ?? $!content.map(*.Hash).Array
+                ?? $!content».Hash
                 !! $!content.Hash;
         %h<stopReason> = $_ with $!stopReason;
         %h<_meta> = $_ with $!meta;


### PR DESCRIPTION
## Summary

- Replace `.map(*.Hash).Array` with `».Hash`
- 15 replacements across Types.rakumod and Server.rakumod
- More concise idiomatic Raku

Closes #178

## Test plan

- [x] All 324 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)