### PR TITLE
Remove redundant return in given/when blocks

### DIFF
--- a/lib/MCP/Server/Prompt.rakumod
+++ b/lib/MCP/Server/Prompt.rakumod
@@ -79,23 +79,19 @@ class RegisteredPrompt is export {
 
         # Normalize to array of PromptMessage
         given $result {
-            when MCP::Types::PromptMessage {
-                return [$result];
-            }
-            when Positional {
-                return $result.Array;
-            }
+            when MCP::Types::PromptMessage { [$result] }
+            when Positional { $result.Array }
             when Str {
-                return [MCP::Types::PromptMessage.new(
+                [MCP::Types::PromptMessage.new(
                     role => 'user',
                     content => MCP::Types::TextContent.new(text => $result)
-                )];
+                )]
             }
             default {
-                return [MCP::Types::PromptMessage.new(
+                [MCP::Types::PromptMessage.new(
                     role => 'user',
                     content => MCP::Types::TextContent.new(text => $result.Str)
-                )];
+                )]
             }
         }
     }

--- a/lib/MCP/Server/Resource.rakumod
+++ b/lib/MCP/Server/Resource.rakumod
@@ -99,32 +99,28 @@ class RegisteredResource is export {
 
         # Normalize result to array of ResourceContents
         given $result {
-            when MCP::Types::ResourceContents {
-                return [$result];
-            }
+            when MCP::Types::ResourceContents { [$result] }
             when Str {
-                return [MCP::Types::ResourceContents.new(
+                [MCP::Types::ResourceContents.new(
                     uri => $!uri,
                     mimeType => $!mimeType // 'text/plain',
                     text => $result
-                )];
+                )]
             }
             when Blob | Buf {
-                return [MCP::Types::ResourceContents.new(
+                [MCP::Types::ResourceContents.new(
                     uri => $!uri,
                     mimeType => $!mimeType // 'application/octet-stream',
                     blob => $result
-                )];
+                )]
             }
-            when Positional {
-                return $result.Array;
-            }
+            when Positional { $result.Array }
             default {
-                return [MCP::Types::ResourceContents.new(
+                [MCP::Types::ResourceContents.new(
                     uri => $!uri,
                     mimeType => 'text/plain',
                     text => $result.Str
-                )];
+                )]
             }
         }
     }
@@ -302,32 +298,28 @@ class RegisteredResourceTemplate is export {
         my $resolved-uri = $uri // $!uri-template;
 
         given $result {
-            when MCP::Types::ResourceContents {
-                return [$result];
-            }
+            when MCP::Types::ResourceContents { [$result] }
             when Str {
-                return [MCP::Types::ResourceContents.new(
+                [MCP::Types::ResourceContents.new(
                     uri => $resolved-uri,
                     mimeType => $!mimeType // 'text/plain',
                     text => $result
-                )];
+                )]
             }
             when Blob | Buf {
-                return [MCP::Types::ResourceContents.new(
+                [MCP::Types::ResourceContents.new(
                     uri => $resolved-uri,
                     mimeType => $!mimeType // 'application/octet-stream',
                     blob => $result
-                )];
+                )]
             }
-            when Positional {
-                return $result.Array;
-            }
+            when Positional { $result.Array }
             default {
-                return [MCP::Types::ResourceContents.new(
+                [MCP::Types::ResourceContents.new(
                     uri => $resolved-uri,
                     mimeType => 'text/plain',
                     text => $result.Str
-                )];
+                )]
             }
         }
     }

--- a/lib/MCP/Server/Tool.rakumod
+++ b/lib/MCP/Server/Tool.rakumod
@@ -106,36 +106,31 @@ class RegisteredTool is export {
 
         # Normalize result to CallToolResult
         given $result {
-            when MCP::Types::CallToolResult {
-                return $result;
-            }
-            when MCP::Types::Content {
-                return MCP::Types::CallToolResult.new(content => [$result]);
-            }
+            when MCP::Types::CallToolResult { $result }
+            when MCP::Types::Content { MCP::Types::CallToolResult.new(content => [$result]) }
             when Hash {
                 # If tool has outputSchema, treat Hash as structuredContent
                 if $!outputSchema {
-                    return MCP::Types::CallToolResult.new(
+                    MCP::Types::CallToolResult.new(
                         structuredContent => $result,
                         content => [MCP::Types::TextContent.new(text => $result.raku)],
                     );
+                } else {
+                    MCP::Types::CallToolResult.new(
+                        content => [MCP::Types::TextContent.new(text => $result.Str)]
+                    );
                 }
-                return MCP::Types::CallToolResult.new(
-                    content => [MCP::Types::TextContent.new(text => $result.Str)]
-                );
             }
             when Str {
-                return MCP::Types::CallToolResult.new(
+                MCP::Types::CallToolResult.new(
                     content => [MCP::Types::TextContent.new(text => $result)]
-                );
+                )
             }
-            when Positional {
-                return MCP::Types::CallToolResult.new(content => $result.Array);
-            }
+            when Positional { MCP::Types::CallToolResult.new(content => $result.Array) }
             default {
-                return MCP::Types::CallToolResult.new(
+                MCP::Types::CallToolResult.new(
                     content => [MCP::Types::TextContent.new(text => $result.Str)]
-                );
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- Remove explicit `return` statements from given/when blocks in Tool, Resource, and Prompt builder modules
- Raku's given/when returns the last expression value, making explicit returns unnecessary
- Simplifies code by collapsing simple cases to single-line expressions

Fixes #179

## Test plan
- [x] All 324 tests pass
- [x] Tool, Resource, and Prompt handlers continue to normalize results correctly

🤖 Generated with [Claude Code](https://claude.ai/code)