### PR TITLE
Use :delete return value directly

### DIFF
--- a/lib/MCP/Server.rakumod
+++ b/lib/MCP/Server.rakumod
@@ -473,9 +473,7 @@ class Server is export {
 
         # Check if request was cancelled - don't send response if so
         my $cancelled = $!flight-lock.protect: {
-            my $c = %!in-flight-requests{$req.id}<cancelled>;
-            %!in-flight-requests{$req.id}:delete;
-            $c
+            (%!in-flight-requests{$req.id}:delete)<cancelled>
         };
         return if $cancelled;
 


### PR DESCRIPTION
## Summary
- Use the `:delete` adverb's return value directly instead of storing it in an intermediate variable
- Simplifies a 3-line block to a single expression

Fixes #180

## Test plan
- [x] All 324 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)